### PR TITLE
Add support to pass modules dir

### DIFF
--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -105,29 +105,30 @@ def read_confs(mdir):
 def main():
     global logger
 
-    plug_conf_fn = os.environ.get(_MOD_ENV,
+    inp = json.load(sys.stdin)
+    pid = inp['pid']
+    cf = json.load(open("config.json"))
+    cf_env = {}
+    for e in cf['process']['env']:
+        k, v = e.split("=", maxsplit=1)
+        cf_env[k] = v
+
+    plug_conf_fn = cf_env.get(_MOD_ENV,
                                   f"{sys.prefix}/etc/podman_hpc/modules.d")
     plug_conf = read_confs(plug_conf_fn)
 
-    lf = os.environ.get("LOG_PLUGIN")
+    lf = cf_env.get("LOG_PLUGIN")
     if lf:
         logger = open(lf, "w")
-    log(os.environ)
-    inp = json.load(sys.stdin)
     log(json.dumps(inp, indent=2))
-    pid = inp['pid']
-    cf = json.load(open("config.json"))
+    log(os.environ)
     log(json.dumps(cf, indent=2))
     rp = cf["root"]["path"]
 
     setns(pid, "mnt")
     os.chroot("/")
-    envs = {}
-    for e in cf['process']['env']:
-        k, v = e.split("=", maxsplit=1)
-        envs[k] = v
     for m in plug_conf:
-        if plug_conf[m]['env'] in envs:
+        if plug_conf[m]['env'] in cf_env:
             log("Loading %s" % (m))
             do_plugin(rp, plug_conf[m], plug_conf_fn)
     ret = os.chroot(rp)

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -104,12 +104,12 @@ def config_storage(conf, additional_stores=None):
     return stor_conf
 
 
-def config_containers(conf, args, confs):
+def config_containers(conf, args, confs, modules_dir):
     """
     Create a container conf object
     """
     cont_conf = conf.get_default_containers_conf()
-    cmds = []
+    cmds = ["-e", "%s=%s" % (_MOD_ENV, modules_dir)]
     for mod, mconf in confs.items():
         cli_arg = mconf["cli_arg"]
         if vars(args).get(cli_arg):
@@ -157,7 +157,7 @@ def read_confs():
     for d in glob(f"{mdir}/*.yaml"):
         conf = yaml.load(open(d), Loader=yaml.FullLoader)
         confs[conf["name"]] = conf
-    return confs
+    return confs, mdir
 
 
 def add_args(parser, confs):
@@ -263,7 +263,7 @@ def main():
         action="store_true",
         help="Force update of storage conf",
     )
-    confs = read_confs()
+    confs, modules_dir = read_confs()
     add_args(parser, confs)
     args, podman_args = parser.parse_known_args()
     if "--help" in podman_args:
@@ -279,7 +279,7 @@ def main():
 
     # Generate Configs
     stor_conf = config_storage(conf, additional_stores=args.additional_stores)
-    cont_conf, cmds = config_containers(conf, args, confs)
+    cont_conf, cmds = config_containers(conf, args, confs, modules_dir)
     overwrite = False
     if args.additional_stores or args.squash_dir or args.update_conf:
         overwrite = True


### PR DESCRIPTION
This enabled the podman_hpc wrapper to pass the modules dir location to the hook script.  This also allows turning on logging in the hook via an podman-hpc -e LOG_PLUGIN.