### PR TITLE
hook_tool off by default

### DIFF
--- a/podman_hpc/configure_hooks.py
+++ b/podman_hpc/configure_hooks.py
@@ -12,11 +12,12 @@ hook_text = cleandoc(
         "version": "1.0.0",
         "hook": {{
             "path": "{os.path.join(sys.prefix,'bin','hook_tool')}",
-            "args": ["hook_tool"],
-            "env": [ "DISABLED_LOG_PLUGIN=/tmp/plugin.log" ]
+            "args": ["hook_tool"]
         }},
         "when": {{
-            "always": true
+            "annotations": {{
+               "podman_hpc.hook_tool": "true"
+            }}
         }},
         "stages": ["prestart"]
     }}

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -14,6 +14,7 @@ import yaml
 
 _MOD_ENV = "PODMANHPC_MODULES_DIR"
 _HOOKS_ENV = "PODMANHPC_HOOKS_DIR"
+_HOOKS_ANNO = "podman_hpc.hook_tool"
 
 
 class config:
@@ -110,6 +111,7 @@ def config_containers(conf, args, confs, modules_dir):
     """
     cont_conf = conf.get_default_containers_conf()
     cmds = ["-e", "%s=%s" % (_MOD_ENV, modules_dir)]
+    cmds.extend(["--annotation", "%s=true" % (_HOOKS_ANNO)])
     for mod, mconf in confs.items():
         cli_arg = mconf["cli_arg"]
         if vars(args).get(cli_arg):


### PR DESCRIPTION
Switch the hook_tool to being enabled via an annotation. This way it isn't on by default.