### PR TITLE
draft: add wildcards in hooks, use absolute paths to config files

### DIFF
--- a/etc/modules.d/exec-wait.yaml
+++ b/etc/modules.d/exec-wait.yaml
@@ -5,4 +5,4 @@ help: Enable exec-wait binary for shared-run mode.
 env: ENABLE_EXEC_WAIT
 copy: []
 bind:
-  - /usr/bin/exec-wait:/usr/bin/exec-wait
+  - ../../bin/exec-wait:/usr/bin/exec-wait

--- a/etc/modules.d/exec-wait.yaml
+++ b/etc/modules.d/exec-wait.yaml
@@ -5,4 +5,4 @@ help: Enable exec-wait binary for shared-run mode.
 env: ENABLE_EXEC_WAIT
 copy: []
 bind:
-  - ../../bin/exec-wait:/usr/bin/exec-wait
+  - ../../../bin/exec-wait:/usr/bin/exec-wait

--- a/etc/modules.d/exec-wait.yaml
+++ b/etc/modules.d/exec-wait.yaml
@@ -5,4 +5,4 @@ help: Enable exec-wait binary for shared-run mode.
 env: ENABLE_EXEC_WAIT
 copy: []
 bind:
-  - ../../bin/exec-wait:/usr/bin/exec-wait
+  - /usr/bin/exec-wait:/usr/bin/exec-wait

--- a/etc/modules.d/exec-wait.yaml
+++ b/etc/modules.d/exec-wait.yaml
@@ -1,8 +1,0 @@
-name: exec-wait
-cli_arg: exec-wait
-hidden: True
-help: Enable exec-wait binary for shared-run mode.
-env: ENABLE_EXEC_WAIT
-copy: []
-bind:
-  - ../../../bin/exec-wait:/usr/bin/exec-wait

--- a/etc/modules.d/gpu.yaml
+++ b/etc/modules.d/gpu.yaml
@@ -5,7 +5,7 @@ env: ENABLE_GPU
 additional_args:
   - -e NVIDIA_VISIBLE_DEVICES
 copy:
-  - ../podman-hpc/01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
+  - ../01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
   - /usr/lib64/libnv*:/usr/lib64/libnv*
   - /usr/lib64/nvidia/libOpenCL*:/usr/lib64/libOpenCL*
   - /usr/lib64/libcuda*:/usr/lib64/libcuda*

--- a/etc/modules.d/gpu.yaml
+++ b/etc/modules.d/gpu.yaml
@@ -5,52 +5,11 @@ env: ENABLE_GPU
 additional_args:
   - -e NVIDIA_VISIBLE_DEVICES
 copy:
-  - ../01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
-  - /usr/lib64/libnvcuvid.so:/usr/lib64/libnvcuvid.so
-  - /usr/lib64/libnvcuvid.so.1:/usr/lib64/libnvcuvid.so.1
-  - /usr/lib64/libnvcuvid.so.515.48.07:/usr/lib64/libnvcuvid.so.515.48.07
-  - /usr/lib64/libnvidia-allocator.so.1:/usr/lib64/libnvidia-allocator.so.1
-  - /usr/lib64/libnvidia-allocator.so.515.48.07:/usr/lib64/libnvidia-allocator.so.515.48.07
-  - /usr/lib64/libnvidia-cfg.so.1:/usr/lib64/libnvidia-cfg.so.1
-  - /usr/lib64/libnvidia-cfg.so.515.48.07:/usr/lib64/libnvidia-cfg.so.515.48.07
-  - /usr/lib64/libnvidia-compiler.so.515.48.07:/usr/lib64/libnvidia-compiler.so.515.48.07
-  - /usr/lib64/libnvidia-eglcore.so.515.48.07:/usr/lib64/libnvidia-eglcore.so.515.48.07
-  - /usr/lib64/libnvidia-egl-wayland.so.1:/usr/lib64/libnvidia-egl-wayland.so.1
-  - /usr/lib64/libnvidia-egl-wayland.so.1.1.9:/usr/lib64/libnvidia-egl-wayland.so.1.1.9
-  - /usr/lib64/libnvidia-encode.so.1:/usr/lib64/libnvidia-encode.so.1
-  - /usr/lib64/libnvidia-encode.so.515.48.07:/usr/lib64/libnvidia-encode.so.515.48.07
-  - /usr/lib64/libnvidia-fbc.so.1:/usr/lib64/libnvidia-fbc.so.1
-  - /usr/lib64/libnvidia-fbc.so.515.48.07:/usr/lib64/libnvidia-fbc.so.515.48.07
-  - /usr/lib64/libnvidia-glcore.so.515.48.07:/usr/lib64/libnvidia-glcore.so.515.48.07
-  - /usr/lib64/libnvidia-glsi.so.515.48.07:/usr/lib64/libnvidia-glsi.so.515.48.07
-  - /usr/lib64/libnvidia-glvkspirv.so.515.48.07:/usr/lib64/libnvidia-glvkspirv.so.515.48.07
-  - /usr/lib64/libnvidia-gtk2.so.515.48.07:/usr/lib64/libnvidia-gtk2.so.515.48.07
-  - /usr/lib64/libnvidia-gtk3.so.515.48.07:/usr/lib64/libnvidia-gtk3.so.515.48.07
-  - /usr/lib64/libnvidia-ml.so:/usr/lib64/libnvidia-ml.so
-  - /usr/lib64/libnvidia-ml.so.1:/usr/lib64/libnvidia-ml.so.1
-  - /usr/lib64/libnvidia-ml.so.515.48.07:/usr/lib64/libnvidia-ml.so.515.48.07
-  - /usr/lib64/libnvidia-ngx.so.1:/usr/lib64/libnvidia-ngx.so.1
-  - /usr/lib64/libnvidia-ngx.so.515.48.07:/usr/lib64/libnvidia-ngx.so.515.48.07
-  - /usr/lib64/libnvidia-opencl.so.1:/usr/lib64/libnvidia-opencl.so.1
-  - /usr/lib64/libnvidia-opencl.so.515.48.07:/usr/lib64/libnvidia-opencl.so.515.48.07
-  - /usr/lib64/libnvidia-opticalflow.so.1:/usr/lib64/libnvidia-opticalflow.so.1
-  - /usr/lib64/libnvidia-opticalflow.so.515.48.07:/usr/lib64/libnvidia-opticalflow.so.515.48.07
-  - /usr/lib64/libnvidia-ptxjitcompiler.so.1:/usr/lib64/libnvidia-ptxjitcompiler.so.1
-  - /usr/lib64/libnvidia-ptxjitcompiler.so.515.48.07:/usr/lib64/libnvidia-ptxjitcompiler.so.515.48.07
-  - /usr/lib64/libnvidia-rtcore.so.515.48.07:/usr/lib64/libnvidia-rtcore.so.515.48.07
-  - /usr/lib64/libnvidia-tls.so.515.48.07:/usr/lib64/libnvidia-tls.so.515.48.07
-  - /usr/lib64/libnvoptix.so.1:/usr/lib64/libnvoptix.so.1
-  - /usr/lib64/libnvoptix.so.515.48.07:/usr/lib64/libnvoptix.so.515.48.07
-  - /usr/lib64/libnvperf_dcgm_host.so:/usr/lib64/libnvperf_dcgm_host.so
-  - /usr/lib64/libnvperf_host.so:/usr/lib64/libnvperf_host.so
-  - /usr/lib64/nvidia/libOpenCL.so.1:/usr/lib64/libOpenCL.so.1
-  - /usr/lib64/nvidia/libOpenCL.so.1.0.0:/usr/lib64/libOpenCL.so.1.0.0
-  - /usr/lib64/libcuda.so:/usr/lib64/libcuda.so
-  - /usr/lib64/libcuda.so.1:/usr/lib64/libcuda.so.1
-  - /usr/lib64/libcuda.so.515.48.07:/usr/lib64/libcuda.so.515.48.07
-  - /opt/cray/pe/mpich/default/gtl/lib/libmpi_gtl_cuda.so:/usr/lib64/libmpi_gtl_cuda.so
-  - /opt/cray/pe/mpich/default/gtl/lib/libmpi_gtl_cuda.so.0:/usr/lib64/libmpi_gtl_cuda.so.0
-  - /opt/cray/pe/mpich/default/gtl/lib/libmpi_gtl_cuda.so.0.0.0:/usr/lib64/libmpi_gtl_cuda.so.0.0.0
+  - /etc/podman-hpc/01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
+  - /usr/lib64/libnv*:/usr/lib64/libnv*
+  - /usr/lib64/nvidia/libOpenCL*:/usr/lib64/libOpenCL*
+  - /usr/lib64/libcuda*:/usr/lib64/libcuda*
+  - /opt/cray/pe/mpich/default/gtl/lib/libmpi_gtl_cuda*:/usr/lib64/libmpi_gtl_cuda*
 bind:
   - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi
   - /dev/nvidiactl:/dev/nvidiactl

--- a/etc/modules.d/gpu.yaml
+++ b/etc/modules.d/gpu.yaml
@@ -5,7 +5,7 @@ env: ENABLE_GPU
 additional_args:
   - -e NVIDIA_VISIBLE_DEVICES
 copy:
-  - /etc/podman-hpc/01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
+  - ../podman-hpc/01-gpu.conf:/etc/ld.so.conf.d/01-gpu.conf
   - /usr/lib64/libnv*:/usr/lib64/libnv*
   - /usr/lib64/nvidia/libOpenCL*:/usr/lib64/libOpenCL*
   - /usr/lib64/libcuda*:/usr/lib64/libcuda*

--- a/etc/modules.d/mpich.yaml
+++ b/etc/modules.d/mpich.yaml
@@ -12,7 +12,7 @@ additional_args:
   - --pid=host
   - --privileged
 copy:
-  - /etc/podman-hpc/02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
+  - ../podman-hpc/02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
 bind:
   - /dev/xpmem:/dev/xpmem
   - /dev/shm:/dev/shm

--- a/etc/modules.d/mpich.yaml
+++ b/etc/modules.d/mpich.yaml
@@ -12,7 +12,7 @@ additional_args:
   - --pid=host
   - --privileged
 copy:
-  - ../podman-hpc/02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
+  - ../02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
 bind:
   - /dev/xpmem:/dev/xpmem
   - /dev/shm:/dev/shm

--- a/etc/modules.d/mpich.yaml
+++ b/etc/modules.d/mpich.yaml
@@ -12,13 +12,13 @@ additional_args:
   - --pid=host
   - --privileged
 copy:
-  - ../02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
+  - /etc/podman-hpc/02-mpich.conf:/etc/ld.so.conf.d/02-mpich.conf
 bind:
   - /dev/xpmem:/dev/xpmem
   - /dev/shm:/dev/shm
   - /dev/ss0:/dev/ss0
   - /dev/cxi*:/dev/cxi*
-  - /usr/lib/shifter/mpich-1.3/:/opt/udiImage/modules/mpich
-  - /opt/cray/libfabric/1.15.0.0/lib64/libfabric:/opt/cray/libfabric/1.15.0.0/lib64/libfabric
+  - /usr/lib/shifter/mpich-2.2:/opt/udiImage/modules/mpich
+  - /opt/cray/libfabric/*/lib64/libfabric:/opt/cray/libfabric/*/lib64/libfabric
   - /var/spool/slurmd:/var/spool/slurmd
   - /etc/libibverbs.d:/etc/libibverbs.d


### PR DESCRIPTION
Updates the hooks to use wildcards instead of absolute library names and versions
- Goal: be more flexible
- Hard to test this, so feedback welcome if it looks unworkable

Changes config file relative paths to absolute paths, in line with our current MR in nersc-cle



