### PR TITLE
Switch to using a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The list of configurable values is:
 * additional_stores_default: (list) additional storage areas
 * hooks_dir: (str) directory for hooks. Note: this should have the podman_hpc hooks tool configured.
 * config_home: (str) directory where the generated configuration files will be written and XDG_CONFIG_HOME will be set.
+* localid_var: (str) environment variable to determine the local node rank (default: `SLURM_LOCALID`)
+* tasks_per_node_var: (str) environment variable to determine the tasks per node (default: `SLURM_STEP_TASKS_PER_NDOE`)
+* ntasks_pattern: (str) regular expression pattern to filter the tasks per node (default: `[0-9]+`)
 
 ### Templating
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,44 @@
 Podman-HPC (`podman-hpc`) is a wrapper script around the Pod Manager (`podman`) container engine,
 which provides HPC configuration and infrastructure for the Podman ecosystem at NERSC.
 
+## Configuration
+
+The wrapper can be configured through a configuration file and environment variables.
+The order of precedence from lowest to highest is:
+
+1. built-in defaults
+1. configuration file template (if a template is allowed)
+1. environment variable template (if a template is allowed)
+1. configuration file
+1. enviornment variables
+
+The enviornment variable override is the configuration parameter in upper case prefixed
+with PODMANHPC_ (e.g. podman_bin becomes PODMANHPC_PODMAN_BIN).
+
+The list of configurable values is:
+* podman_bin: (str) path to the podman binary (default: podman)
+* mount_program: (str) path the mount_program wrapper (default: fuse-overlayfs-wrap)
+* modules_dir: (str) directory of podman-hpc modules
+* shared_run_exec_args: (str) additional arguments passed to the exec command when using shared_run mode (default: None)
+* shared_run_command: (list) command to run in the shared_run container (default: sleep infinity)
+* graph_root: (str) directory for the graph root (default: /tmp/{uid}_hpc/storage)
+* run_root: (str) directory for teh run root (default: /tmp/{uid}_hpc)
+* default_args: additional arguments to pass to podman (future)
+* default_run_args: additional run arguments (future)
+* additional_stores_default: (list) additional storage areas
+* hooks_dir: (str) directory for hooks. Note: this should have the podman_hpc hooks tool configured.
+* config_home: (str) directory where the generated configuration files will be written and XDG_CONFIG_HOME will be set.
+
+### Templating
+
+Some parameters can be set using a template.  The template is set by the parameter with `_template` appended to the parameter to
+be templated (e.g. graph_root_template would be used to generate the value for the graph_root parameter).
+
+The template replaces strings with `{{ variable }}` with the approriate value. The following variables are supported.
+* uid: replaced with the user id of the calling user
+* user: replaced with the user name of the calling user
+* env.VARIABLE: replaced with the value of the environment `VARIABLE`.  For example, env.HOME would be replaced with the value of `HOME`.
+
 ## Prerequisites
 1. `podman` should be installed separately, per the instructions at https://podman.io/
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The list of configurable values is:
 * run_root: (str) directory for teh run root (default: /tmp/{uid}_hpc)
 * default_args: additional arguments to pass to podman (future)
 * default_run_args: additional run arguments (future)
-* additional_stores_default: (list) additional storage areas
+* additional_stores: (list) additional storage areas
 * hooks_dir: (str) directory for hooks. Note: this should have the podman_hpc hooks tool configured.
 * config_home: (str) directory where the generated configuration files will be written and XDG_CONFIG_HOME will be set.
 * localid_var: (str) environment variable to determine the local node rank (default: `SLURM_LOCALID`)

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -6,7 +6,6 @@ import socket
 import re
 import time
 import click
-import re
 from . import click_passthrough as cpt
 from .migrate2scratch import MigrateUtils
 from .siteconfig import SiteConfig
@@ -47,7 +46,7 @@ with os.popen("podman --help") as fid:
         text = re.sub(
             "^.+(?=(Available Commands))", "\b\n", fid.read(), flags=re.DOTALL
         )
-        podman_epilog = re.sub("(\n\s*\n)(?=\S)", "\n\n\b\n", text)
+        podman_epilog = re.sub(r"(\n\s*\n)(?=\S)", "\n\n\b\n", text)
     except Exception:
         podman_epilog = "For additional commands please see `podman --help`."
 os.environ = initenv
@@ -104,14 +103,13 @@ def podhpc(ctx, additional_stores, squash_dir, update_conf, log_level):
     conf.config_containers()
     conf.config_env(hpc=True)
 
-    # optionally, save the storage conf
-    conf.export_storage_conf(overwrite=overwrite)
-    conf.export_containers_conf(overwrite=overwrite)
-
     # add appropriate flags to call_podman based on invoked subcommand
     # defcmd = ctx.command.default_command_fn
     invcmd = ctx.command.get_command(ctx, ctx.invoked_subcommand)
     for k, v in conf.sitemods.get(ctx.invoked_subcommand, {}).items():
+        if 'cli_arg' not in v:
+            continue
+        print(v)
         invcmd = click.option(
             f"--{v['cli_arg']}",
             is_flag=True,

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -2,47 +2,102 @@ import sys
 import os
 import shutil
 import toml
-import yaml
+import re
+from yaml import load
+from yaml import FullLoader
 from copy import deepcopy
 from glob import glob
 
-_MOD_ENV = "PODMANHPC_MODULES_DIR"
-_HOOKS_ENV = "PODMANHPC_HOOKS_DIR"
+_ENV_PREFIX = "PODMANHPC"
+_MOD_ENV = f"{_ENV_PREFIX}_MODULES_DIR"
 _HOOKS_ANNO = "podman_hpc.hook_tool"
+_CONF_ENV = f"{_ENV_PREFIX}_CONFIG_FILE"
 
 
 class SiteConfig:
     """
     Class to represent site specific configurations for Podman-HPC.
+
+    Precedence order lowest to highest:
+    - Built-in defaults
+    - Config file
+    - Environment variables
     """
 
+    _default_conf_file = "/etc/podman_hpc/podman_hpc.yaml"
+    _valid_params = ["podman_bin", "mount_program", "modules_dir",
+                     "shared_run_exec_args", "shared_run_command",
+                     "graph_root", "run_root",
+                     "default_args", "default_run_args",
+                     "additional_stores_default", "hooks_dir",
+                     "config_home"]
+    _valid_templates = ["shared_run_args_template",
+                        "graph_root_template",
+                        "run_root_template",
+                        "default_args_template",
+                        "default_run_args_template",
+                        "additional_stores_default_template",
+                        "config_home_template"
+                        ]
+    _uid = os.getuid()
+    _xdg_base = f"/tmp/{_uid}_hpc"
+    config_home = f"{_xdg_base}/config"
+    run_root = _xdg_base
+    additional_stores_default = None
+    default_args = []
+    hooks_dir = f"{sys.prefix}/share/containers/oci/hooks.d"
+    graph_root = f"{_xdg_base}/storage"
+    squash_dir = os.environ.get(
+        "SQUASH_DIR", f'{os.environ.get("SCRATCH", "/tmp")}/storage'
+    )
+    modules_dir = "/etc/podman_hpc/modules.d"
+    shared_run_exec_args = []
+    default_run_args = []
+    shared_run_command = ["sleep", "infinity"]
+    podman_bin = "podman"
+    mount_program = "fuse-overlayfs-warp"
+    runtime = "runc"
+
     def __init__(self, squash_dir=None, log_level=None):
-        self.uid = os.getuid()
+
+        # getlogin may fail on a compute node
         try:
             self.user = os.getlogin()
         except Exception:
             self.user = os.environ["USER"]
-        self.xdg_base = f"/tmp/{self.uid}_hpc"
-        self.run_root = self.xdg_base
-        self.graph_root = f"{self.xdg_base}/storage"
-        self.squash_dir = squash_dir or os.environ.get(
-            "SQUASH_DIR", f'{os.environ["SCRATCH"]}/storage'
-        )
-        self.modules_dir = os.environ.get(
-            _MOD_ENV, "/etc/podman_hpc/modules.d"
-        )
+        # TODO: move these as a test at the end
         self.podman_bin = self.trywhich("podman")
         self.mount_program = self.trywhich("fuse-overlayfs-wrap")
-        self.conmon_bin = self.trywhich("conmon")
         try:
             self.runtime = self.trywhich("crun")
         except OSError:
             self.runtime = self.trywhich("runc")
-        self.options = []
+        # self.options = []
+        self.conf_file_data = {}
+        self._read_config_file()
+        for param in self._valid_templates:
+            self._check_and_set(param)
+        for param in self._valid_params:
+            self._check_and_set(param)
+
+        self.read_site_modules()
         self.log_level = log_level
+
+    def dump_config(self):
+        """
+        Debug method to dump the configuration
+        """
+
+        for param in self._valid_params:
+            val = str(getattr(self, param))
+            print(f"{param}: {val}")
+        print(f"active_modules: {self.active_modules}")
 
     @staticmethod
     def trywhich(cmd, *args, **kwargs):
+        """
+        Use which and raise an error if it can't be found.
+        """
         res = shutil.which(cmd, *args, **kwargs)
         if res is None:
             raise OSError(
@@ -50,7 +105,70 @@ class SiteConfig:
             )
         return res
 
+    def _check_and_set(self, attr: str, envname=None, parname=None):
+        """
+        Helper function to apply the right precedence
+        """
+        if not parname:
+            parname = attr
+        if not envname:
+            uppar = attr.upper()
+            envname = f"{_ENV_PREFIX}_{uppar}"
+
+        setval = False
+        if envname in os.environ:
+            setval = True
+            newval = os.environ[envname]
+        elif parname in self.conf_file_data:
+            setval = True
+            newval = self.conf_file_data[parname]
+        if setval and attr.endswith("_template"):
+            setattr(self, attr, newval)
+            newval = self._apply_template(newval)
+            attr = attr.replace("_template", "")
+
+        # TODO: add type validation (e.g. str or list)
+        if setval:
+            setattr(self, attr, newval)
+
+    def _apply_template(self, templ):
+        """
+        Helper function to convert templates
+        """
+        def _templ(val):
+            val = val.replace("{{ user }}", self.user)
+            val = val.replace("{{ uid }}", str(self._uid))
+            for pat in re.findall(r'{{ env\.[A-Za-z0-9]+ }}', val):
+                envname = pat.replace("{{ env.", "").replace(" }}", "")
+                val = val.replace(pat, os.environ[envname])                
+            return val
+
+        if isinstance(templ, list):
+            newlist = []
+            for item in templ:
+                newlist.append(_templ(item))
+            return newlist
+        elif isinstance(templ, str):
+            return _templ(templ)
+        else:
+            raise ValueError("Can handle template type")
+
+    def _read_config_file(self):
+        """
+        Read the global config file
+        """
+        config_file = os.environ.get(_CONF_ENV, self._default_conf_file)
+        if not os.path.exists(config_file):
+            return
+        self.conf_file_data = load(open(config_file), Loader=FullLoader)
+        for p in self.conf_file_data:
+            if p not in self._valid_params and p not in self._valid_templates:
+                raise ValueError(f"Unrecongnized Option: {p}")
+
     def get_default_store_conf(self):
+        """
+        Generate a default storage conf object
+        """
         return {
             "storage": {
                 "driver": "overlay",
@@ -71,6 +189,9 @@ class SiteConfig:
         }
 
     def get_default_containers_conf(self):
+        """
+        Generate a default containers conf object
+        """
         return {
             "engine": {
                 "cgroup_manager": "cgroupfs",
@@ -79,9 +200,6 @@ class SiteConfig:
                 "seccomp_profile": "unconfined",
             },
         }
-
-    def get_config_home(self):
-        return f"{self.xdg_base}/config"
 
     def config_storage(self, additional_stores=None):
         """
@@ -104,10 +222,12 @@ class SiteConfig:
     def config_env(self, hpc):
         """
         Generate the environment setup
+
+        TODO: Redo this
         """
         new_env = deepcopy(os.environ)
         if hpc:
-            new_env["XDG_CONFIG_HOME"] = self.get_config_home()
+            new_env["XDG_CONFIG_HOME"] = self.config_home
             new_env.pop("XDG_RUNTIME_DIR", None)
         self.env = new_env
 
@@ -116,32 +236,40 @@ class SiteConfig:
         Write out a conf file
         """
         os.makedirs(
-            f"/tmp/containers-user-{self.uid}/containers", exist_ok=True
+            f"/tmp/containers-user-{self._uid}/containers", exist_ok=True
         )
-        os.makedirs(f"{self.get_config_home()}/containers", exist_ok=True)
-        fp = os.path.join(self.get_config_home(), "containers", filename)
+        os.makedirs(f"{self.config_home}/containers", exist_ok=True)
+        fp = os.path.join(self.config_home, "containers", filename)
         if not os.path.exists(fp) or overwrite:
             with open(fp, "w") as f:
                 toml.dump(data, f)
 
     def export_storage_conf(self, filename="storage.conf", overwrite=False):
+        """
+        Write out the storage.conf file
+        """
         self._write_conf(filename, self.storage_conf, overwrite=overwrite)
 
     def export_containers_conf(
         self, filename="containers.conf", overwrite=False
     ):
+        """
+        Write out the containers.conf file
+        """
         self._write_conf(filename, self.container_conf, overwrite=overwrite)
 
     def get_cmd_extensions(self, subcommand, args):
+        """
+        Generate the podman command-line parameters
+
+        subcomand: run, images, etc
+        """
         cmds = []
         if subcommand == "run":
             cmds.extend(
                 [
                     "--hooks-dir",
-                    os.environ.get(
-                        _HOOKS_ENV,
-                        f"{sys.prefix}/share/containers/oci/hooks.d",
-                    ),
+                    self.hooks_dir,
                     "-e",
                     f"{_MOD_ENV}={self.modules_dir}",
                     "--annotation",
@@ -164,7 +292,10 @@ class SiteConfig:
     # flags for any podman subcommand.
     def read_site_modules(self):
         mods = {}
+        active_mods = []
         for modfile in glob(f"{self.modules_dir}/*.yaml"):
-            mod = yaml.load(open(modfile), Loader=yaml.FullLoader)
+            mod = load(open(modfile), Loader=FullLoader)
             mods[mod["name"]] = mod
+            active_mods.append(modfile)
+        self.active_modules = active_mods
         self.sitemods = {"run": mods, "shared-run": mods}

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -30,6 +30,7 @@ class SiteConfig:
                      "graph_root", "run_root",
                      "default_args", "default_run_args",
                      "additional_stores_default", "hooks_dir",
+                     "localid_var", "tasks_per_node_var", "ntasks_pattern",
                      "config_home"]
     _valid_templates = ["shared_run_args_template",
                         "graph_root_template",
@@ -51,12 +52,15 @@ class SiteConfig:
         "SQUASH_DIR", f'{os.environ.get("SCRATCH", "/tmp")}/storage'
     )
     modules_dir = "/etc/podman_hpc/modules.d"
-    shared_run_exec_args = []
+    shared_run_exec_args = ["-e", "SLURM_*", "-e", "PALS_*", "-e", "PMI_*"]
     default_run_args = []
     shared_run_command = ["sleep", "infinity"]
     podman_bin = "podman"
     mount_program = "fuse-overlayfs-warp"
     runtime = "runc"
+    localid_var = "SLURM_LOCALID"
+    tasks_per_node_var = "SLURM_STEP_TASKS_PER_NDOE"
+    ntasks_pattern = r'[0-9]+'
 
     def __init__(self, squash_dir=None, log_level=None):
 
@@ -140,7 +144,7 @@ class SiteConfig:
             val = val.replace("{{ uid }}", str(self._uid))
             for pat in re.findall(r'{{ env\.[A-Za-z0-9]+ }}', val):
                 envname = pat.replace("{{ env.", "").replace(" }}", "")
-                val = val.replace(pat, os.environ[envname])                
+                val = val.replace(pat, os.environ[envname])
             return val
 
         if isinstance(templ, list):

--- a/test/mock_bin/conmon
+++ b/test/mock_bin/conmon
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# This does nothing

--- a/test/mock_bin/runc
+++ b/test/mock_bin/runc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# This does nothing

--- a/test/test_conf.yaml
+++ b/test/test_conf.yaml
@@ -1,0 +1,24 @@
+podman_bin: /bin/sleep
+modules_dir: /tmp/podman_hpc
+shared_run_exec_args:
+  - -e SLURM_*
+  - -e PALS_*
+  - -e PMI_*
+shared_run_command: ["bogus"]
+graph_root_template: "/imagedir/{{ user }}/storage"
+run_root_template: "/tmp/{{ user }}/run"
+mount_program: /bin/sleep
+additional_stores_default:
+  - extra
+
+default_args_template:
+  - --root /images/{{ user }}/storage
+  - --runroot /tmp/{{ uid }}/
+  - --test {{ env.FOO }}
+
+default_run_args:
+  - seccomp-policy unconfined
+
+# On hold
+# storage_conf_template: /etc/podman_hpc/storage.conf.tmpl
+# containers_conf_template: /etc/podman_hpc/containers.conf.tmpl

--- a/test/test_conf.yaml
+++ b/test/test_conf.yaml
@@ -6,9 +6,9 @@ shared_run_exec_args:
   - -e PMI_*
 shared_run_command: ["bogus"]
 graph_root_template: "/imagedir/{{ user }}/storage"
-run_root_template: "/tmp/{{ user }}/run"
+run_root_template: "/tmp/{{ uid }}/run"
 mount_program: /bin/sleep
-additional_stores_default:
+additional_stores:
   - extra
 
 default_args_template:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,81 @@
+import podman_hpc.siteconfig as config
+import os
+import pytest
+
+
+@pytest.fixture
+def fix_paths(monkeypatch):
+    test_dir = os.path.dirname(__file__)
+    mock_dir = os.path.join(test_dir, "mock_bin")
+    bin_dir = os.path.join(test_dir, "..", "bin")
+    monkeypatch.setenv("PATH", mock_dir, prepend=os.pathsep)
+    monkeypatch.setenv("PATH", bin_dir, prepend=os.pathsep)
+
+
+@pytest.fixture
+def conf_file(monkeypatch):
+    test_dir = os.path.dirname(__file__)
+    test_conf = os.path.join(test_dir, "test_conf.yaml")
+    monkeypatch.setenv(config._CONF_ENV, test_conf)
+    monkeypatch.setenv("FOO", "BAR")
+
+
+def test_conf_defaults(fix_paths):
+    conf = config.SiteConfig(squash_dir="/tmp")
+    uid = os.getuid()
+    assert conf.run_root == f"/tmp/{uid}_hpc"
+    assert conf._xdg_base == f"/tmp/{uid}_hpc"
+    assert conf.config_home == f"/tmp/{uid}_hpc/config"
+    assert conf.get_default_store_conf() is not None
+    assert conf.get_default_containers_conf() is not None
+    conf.config_env(True)
+    assert conf.env is not None
+
+
+def test_conf_file(fix_paths, conf_file, monkeypatch):
+    monkeypatch.setenv("FOO", "BAR")
+    conf = config.SiteConfig(squash_dir="/tmp")
+    uid = os.getuid()
+    user = os.getlogin()
+    assert conf.podman_bin == "/bin/sleep"
+    assert conf.mount_program == "/bin/sleep"
+    assert "-e SLURM_*" in conf.shared_run_exec_args
+    assert "bogus" in conf.shared_run_command
+    assert user in conf.graph_root
+    assert user in conf.run_root
+    assert f"--root /images/{user}/storage" in conf.default_args
+    assert f"--runroot /tmp/{uid}/" in conf.default_args
+    assert f"--test BAR" in conf.default_args
+
+
+def test_conf_modules(fix_paths, monkeypatch):
+    test_dir = os.path.dirname(__file__)
+    modules_dir = os.path.join(test_dir, "..", "etc", "modules.d")
+    monkeypatch.setenv("PODMANHPC_MODULES_DIR", modules_dir)
+    conf = config.SiteConfig(squash_dir="/tmp")
+    assert len(conf.active_modules) > 0
+
+
+def test_conf_prec(conf_file, fix_paths, monkeypatch):
+    test_dir = os.path.dirname(__file__)
+    modules_dir = os.path.join(test_dir, "..", "etc", "modules.d")
+    monkeypatch.setenv("PODMANHPC_MODULES_DIR", modules_dir)
+    conf = config.SiteConfig(squash_dir="/tmp")
+    assert conf.modules_dir == modules_dir
+
+
+#    def get_default_store_conf(self):
+#    def get_default_containers_conf(self):
+#    def get_config_home(self):
+#    def config_storage(self, additional_stores=None):
+#        sc = self.get_default_store_conf()
+#        ais = sc["storage"]["options"].setdefault("additionalimagestores", [])
+#    def config_containers(self):
+#        cc = self.get_default_containers_conf()
+#    def config_env(self, hpc):
+#    def _write_conf(self, filename, data, overwrite=False):
+#    def export_storage_conf(self, filename="storage.conf", overwrite=False):
+#    def export_containers_conf(
+#    def get_cmd_extensions(self, subcommand, args):
+#    # to parse appropriately.  This would allow adding site-specific default
+#    def read_site_modules(self):

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -41,6 +41,7 @@ def dst():
 def test_init_storage(src):
     with TemporaryDirectory() as dst:
         mu = MigrateUtils(src=src, dst=dst)
+        mu._lazy_init()
         mu.dst.init_storage()
         idir = os.path.join(dst, "overlay-images")
         assert os.path.exists(idir)
@@ -61,6 +62,7 @@ def test_migrate_remove(src, tmp_path, mocker):
     # Mock Popen
     popen = mocker.patch("podman_hpc.migrate2scratch.Popen")
     mu = MigrateUtils(src=src, dst=tmp_path)
+    mu._lazy_init()
     mu.dst.init_storage()
     imgf = os.path.join(tmp_path, "overlay-images/images.json")
     with open(imgf, "w") as f:

--- a/test/test_podman_hpc.py
+++ b/test/test_podman_hpc.py
@@ -5,8 +5,7 @@ import os
 
 def test_conf():
     conf = phpc.config()
-    home = conf.get_config_home()
-    assert home is not None
+    assert conf.config_home is not None
 
 
 def test_sconf():

--- a/test/test_podman_hpc.py
+++ b/test/test_podman_hpc.py
@@ -1,33 +1,24 @@
 import podman_hpc.podman_hpc as phpc
 import sys
 import os
+import pytest
 
 
-def test_conf():
-    conf = phpc.config()
-    assert conf.config_home is not None
+@pytest.fixture
+def fix_paths(monkeypatch):
+    test_dir = os.path.dirname(__file__)
+    mock_dir = os.path.join(test_dir, "mock_bin")
+    bin_dir = os.path.join(test_dir, "..", "bin")
+    monkeypatch.setenv("PATH", mock_dir, prepend=os.pathsep)
+    monkeypatch.setenv("PATH", bin_dir, prepend=os.pathsep)
 
 
-def test_sconf():
-    conf = phpc.config()
-    sconf = conf.get_default_store_conf()
-    assert 'storage' in sconf
-    assert 'options' in sconf['storage']
-    assert 'mount_program' in sconf['storage']['options']
-
-
-def test_cconf():
-    conf = phpc.config()
-    sconf = conf.get_default_containers_conf()
-    assert 'engine' in sconf
-    assert 'containers' in sconf
-
-
-def test_main(monkeypatch):
-    sys.argv = ["podman_hpc", "--help"]
+def test_main(monkeypatch, fix_paths):
+    sys.argv = ["podman_hpc", "run", "--help"]
     global args_passed
+    args_passed = []
 
-    def mock_exit():
+    def mock_exit(exit_code):
         return 0
 
     def mock_execve(bin, args, path):
@@ -41,6 +32,5 @@ def test_main(monkeypatch):
     assert "--help" in args_passed
 
     sys.argv = ["podman_hpc", "run", "-it", "alpine"]
-    monkeypatch.setattr(os, "execve", mock_execve)
     phpc.main()
     assert "run" in args_passed


### PR DESCRIPTION
This cleans up how the configuration handling and makes it more flexible.  This also shifts to passing all of the podman configuration through command-line parameters to podman versus writing out configuration files.  It also contains some pep8 cleanup and testing improvements.