### PR TITLE
a few more bind/copy fixes

### DIFF
--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -69,12 +69,6 @@ def ldconfig():
         log(f"ldconfig failed: {ret}")
 
 
-def resolve_src(src, modulesd=os.path.abspath("")):
-    if not os.path.isabs(src):
-        src = os.path.join(modulesd, src)
-    return os.path.abspath(os.path.expandvars(src))
-
-
 def resolve_sources_and_destinations(rule, root_path, modulesd=os.path.abspath("")):
     # extract source and destination patterns from the rule
     rs,rd = (rule+":").split(":")[:2]

--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -57,13 +57,13 @@ def copy(src, tgt, symlinks=True):
     if os.path.isdir(src):
         shutil.copytree(
             src,
-            dst,
+            tgt,
             symlinks=symlinks,
             copy_function=shutil.copyfile,
             dirs_exist_ok=True,
         )
     else:
-        shutil.copyfile(src, dst, follow_symlinks=(not symlinks))
+        shutil.copyfile(src, tgt, follow_symlinks=(not symlinks))
 
 
 def ldconfig():

--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -8,7 +8,8 @@ import subprocess
 import json
 import yaml
 import shutil
-from glob import glob
+import re
+from glob import glob, iglob
 
 _MOD_ENV = "PODMANHPC_MODULES_DIR"
 

--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -52,6 +52,13 @@ def bind_mount(src, tgt):
     subprocess.check_output(["mount", "--rbind", src, tgt])
 
 
+def copy(src, tgt, symlinks=True):
+    if os.path.isdir(src):
+        shutil.copytree(src, dst, symlinks=symlinks, copy_function=shutil.copyfile, dirs_exist_ok=True)¶
+    else:
+        shutil.copyfile(src, dst, follow_symlinks=(not symlinks))
+
+
 def ldconfig():
     if not os.path.exists("/sbin/ldconfig"):
         return

--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -149,7 +149,7 @@ def do_plugin(rp, mod, modulesd):
     actions = {"copy": copy, "bind": bind_mount}
 
     for a in actions:
-        for rule in mod.get(a, []):
+        for rule in mod.get(a) or []:
             log(f"\t{rule}")
             for src, tgt in resolve_src_and_dest(rule, rp, modulesd).items():
                 os.makedirs(os.path.dirname(tgt), exist_ok=True)

--- a/podman_hpc/hook_tool.py
+++ b/podman_hpc/hook_tool.py
@@ -75,6 +75,58 @@ def resolve_src(src, modulesd=os.path.abspath("")):
     return os.path.abspath(os.path.expandvars(src))
 
 
+def resolve_sources_and_destinations(rule, root_path, modulesd=os.path.abspath("")):
+    # extract source and destination patterns from the rule
+    rs,rd = (rule+":").split(":")[:2]
+    
+    # expand vars
+    rs = os.path.expanduser(os.path.expandvars(rs))
+    rd = os.path.expanduser(os.path.expandvars(rd))
+
+    # ensure source pattern is absolute path
+    if not os.path.isabs(rs):
+            rs = os.path.join(modulesd, rs)
+    rs = os.path.abspath(os.path.expanduser(os.path.expandvars(rs)))    
+
+    # error checks
+    if not os.path.isabs(rd):
+        log(f"Error: Destination in pattern must be an absolute path.\n\tdestination: {rd}")
+        return {}
+    if '*' in rd:
+            if rs.count('*')!=1:
+                log(
+                        "Error: Using glob '*' in destination requires exactly one glob '*' in source."
+                        f"\n\tsource: {rs}\n\tdestination: {rd}"
+                        )
+                return {}
+            else:
+                # this is used to capture the glob expansion later
+                globstrip = "^{}|{}$".format(*rs.split('*'))
+    
+    # determine how to construct absolute path to destination object
+    # if no destination rule is given, use the path from source rule
+    if rd=="": 
+        dest = lambda src: os.path.join(root_path,src[1:])
+    # if the destination rule reuses the glob pattern, trailing path separator 
+    # determines if it interpreted as a directory or obj name
+    elif '*' in rd and rd[-1]==os.path.sep:
+        dest = lambda src: os.path.join(root_path,rd.replace('*',re.sub(globstrip,"",src))[1:], os.path.basename(src))
+    elif '*' in rd and rd[-1]!=os.path.sep:
+        dest = lambda src: os.path.join(root_path,rd.replace('*',re.sub(globstrip,"",src))[1:])
+    # if we glob multiple sources, interpret destination as a directory, and append shortest unique path
+    elif (1 < len(glob(rs))):
+        common_prefix = os.path.commonpath(glob(rs))
+        dest = lambda src: os.path.join(root_path,rd[1:],os.path.relpath(src,common_prefix))
+    # otherwise, trailing path separator determines whether destination is interpreted as a directory
+    elif rd[-1]==os.path.sep:
+        dest = lambda src: os.path.join(root_path,rd[1:],os.path.basename(src))
+    else:
+        dest = lambda src: os.path.join(root_path,rd[1:])
+    
+    return {src:os.path.normpath(dest(src)) for src in iglob(rs)}       
+
+
+
 def do_plugin(rp, mod, modulesd):
     """
     set up to do copies and bind mounts


### PR DESCRIPTION
Changes `bind` to `rbind` to address https://github.com/NERSC/podman-hpc/issues/40

Another lingering change needed to fix the wildcard bind-mount logic in https://github.com/NERSC/podman-hpc/issues/36

There are some situations where we might always have something to copy or bind (like in the NCCL module), so I added logic to handle this via `if mod["copy"] is not None:` etc 

