### PR TITLE
Don't use additional store for build command

### DIFF
--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -326,6 +326,8 @@ class SiteConfig:
         cmds.extend(self.default_args)
         if subcommand == "run":
             cmds.extend(self.default_run_args)
+        elif subcommand == "build":
+            cmds = self.default_pull_args
         for mod, mconf in self.sitemods.get(subcommand, {}).items():
             if 'cli_arg' not in mconf:
                 continue


### PR DESCRIPTION
This makes sure that the squash storage don't get added during a build.