### PR TITLE
fixed typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ console_scripts =
     etc/podman_hpc/modules.d =
       etc/modules.d/gpu.yaml
       etc/modules.d/mpich.yaml
-      etc/modules/d/cuda-mpich.yaml
+      etc/modules.d/cuda-mpich.yaml
       etc/modules.d/nccl.yaml
       etc/modules.d/cvmfs.yaml
 


### PR DESCRIPTION
There was a typo and now there is not a typo.  I am going to self approve this because it is trivial.