### PR TITLE
add pat's suggested fuse wrapper fix

### DIFF
--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -7,19 +7,19 @@ UMOUNT_WAIT_RETRIES=${UMOUNT_WAIT_RETRIES:-"5"}
 UMOUNT_WAIT_DELAY=${UMOUNT_WAIT_DELAY:-"1"}
 
 if [ "$1" = "wait" ] ; then
-inotifywait -e delete $2/etc
+    inotifywait -e delete $2/etc
 
-for i in $(seq $UMOUNT_WAIT_RETRIES); do
-    umount -v $3 >> $LOG 2>&1
-    if [ $? -ne 0 ]; then
-        # Sleep to let podman clean up
-        echo "Retry umount after sleep $UMOUNT_WAIT_DELAY second(s)" >> $LOG
-        sleep $UMOUNT_WAIT_DELAY
-    else
-        break
-    fi
-done
-exit
+    for i in $(seq $UMOUNT_WAIT_RETRIES); do
+        umount -v $3 >> $LOG 2>&1
+        if [ $? -ne 0 ]; then
+            # Sleep to let podman clean up
+            echo "Retry umount after sleep $UMOUNT_WAIT_DELAY second(s)" >> $LOG
+            sleep $UMOUNT_WAIT_DELAY
+        else
+            break
+        fi
+    done
+    exit
 fi
 
 F=$(echo $@|sed 's/,upperdir.*//'|sed 's/.*lowerdir=//')

--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -2,10 +2,24 @@
 
 LOG=/tmp/fow-$(id -u).log
 LOG=/dev/null
+
+UMOUNT_WAIT_RETRIES=${UMOUNT_WAIT_RETRIES:-"5"}
+UMOUNT_WAIT_DELAY=${UMOUNT_WAIT_DELAY:-"1"}
+
 if [ "$1" = "wait" ] ; then
-    inotifywait -e delete $2/etc
-    umount $3
-    exit
+inotifywait -e delete $2/etc
+
+for i in $(seq $UMOUNT_WAIT_RETRIES); do
+    umount -v $3 >> $LOG 2>&1
+    if [ $? -ne 0 ]; then
+        # Sleep to let podman clean up
+        echo "Retry umount after sleep $UMOUNT_WAIT_DELAY second(s)" >> $LOG
+        sleep $UMOUNT_WAIT_DELAY
+    else
+        break
+    fi
+done
+exit
 fi
 
 F=$(echo $@|sed 's/,upperdir.*//'|sed 's/.*lowerdir=//')


### PR DESCRIPTION
Addresses https://github.com/NERSC/podman-hpc/issues/54

Adds a sleep and an extra check to ensure the umount has succeeded and podman will not exit and leave behind mounts

Note I have not tested this 