### PR TITLE
return nonzero exit code from failed pull

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -177,7 +177,7 @@ def pull(ctx, siteconf, image, podman_args):
         mu.migrate_image(image)
     else:
         sys.stderr.write("Pull failed.\n")
-
+        sys.exit(proc.returncode)
 
 # podman-hpc shared-run subcommand #########################################
 @podhpc.command(

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -169,19 +169,14 @@ def pull(ctx, siteconf, image, podman_args):
     cmd.extend(podman_args)
     cmd.extend(siteconf.default_pull_args)
     cmd.append(image)
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    stdout_data, stderr_data = proc.communicate()
-    # write to both stdout and stderr
-    sys.stdout.write(stdout_data)
-    # somewhat surprisingly podman routes container pull output to stderr
-    sys.stderr.write(stderr_data)
-
+    proc = Popen(cmd)
+    proc.communicate()
     if proc.returncode == 0:
         sys.stdout.write(f"INFO: Migrating image to {siteconf.squash_dir}\n")
         mu = MigrateUtils(conf=siteconf)
         mu.migrate_image(image)
     else:
-        sys.stderr.write("Pull failed\n")
+        sys.stderr.write("Pull failed.\n")
         sys.exit(proc.returncode)
 
 


### PR DESCRIPTION
Addresses https://github.com/NERSC/podman-hpc/issues/57 

Thanks for the report @wholtz

Have tested:

```
stephey@nid001013:/mscratch/sd/s/stephey> podman-hpc pull docker.io/debian:not_a_real_tag
Trying to pull docker.io/library/debian:not_a_real_tag...
Error: initializing source docker://debian:not_a_real_tag: reading manifest not_a_real_tag in docker.io/library/debian: manifest unknown: manifest unknown
Pull failed.
stephey@nid001013:/mscratch/sd/s/stephey> echo $?
125
stephey@nid001013:/mscratch/sd/s/stephey> podman-hpc pull ubuntu:latest 
Trying to pull docker.io/library/ubuntu:latest...
Getting image source signatures
Copying blob dbf6a9befcde skipped: already exists  
Copying config 3b418d7b46 done  
Writing manifest to image destination
Storing signatures
3b418d7b466ac6275a6bfcb0c86fbe4422ff6ea0af444a294f82d3bf5173ce74
INFO: Migrating image to /mscratch/sd/s/stephey/storage
stephey@nid001013:/mscratch/sd/s/stephey> echo $?
0
stephey@nid001013:/mscratch/sd/s/stephey> 
```
