### PR TITLE
use default args for build, enable building on computes

### DIFF
--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -328,8 +328,6 @@ class SiteConfig:
         cmds.extend(self.default_args)
         if subcommand == "run":
             cmds.extend(self.default_run_args)
-        elif subcommand == "build":
-            cmds = self.default_pull_args
         for mod, mconf in self.sitemods.get(subcommand, {}).items():
             if 'cli_arg' not in mconf:
                 continue

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -55,6 +55,7 @@ class SiteConfig:
     shared_run_exec_args = ["-e", "SLURM_*", "-e", "PALS_*", "-e", "PMI_*"]
     default_run_args = []
     default_pull_args = []
+    default_build_args = []
     shared_run_command = ["sleep", "infinity"]
     podman_bin = "podman"
     mount_program = "fuse-overlayfs-warp"
@@ -117,6 +118,16 @@ class SiteConfig:
                     "--runroot", self.run_root,
                     "--cgroup-manager", "cgroupfs",
                     ]
+        if len(self.default_build_args) == 0:
+            self.default_build_args = [
+                    "--root", self.graph_root,
+                    "--runroot", self.run_root,
+                    "--storage-opt",
+                    f"mount_program={self.mount_program}",
+                    "--storage-opt",
+                    "ignore_chown_errors=true",
+                    "--cgroup-manager", "cgroupfs",
+                    ]            
         self.log_level = log_level
 
     def dump_config(self):
@@ -328,6 +339,8 @@ class SiteConfig:
         cmds.extend(self.default_args)
         if subcommand == "run":
             cmds.extend(self.default_run_args)
+        elif subcommand == "build":
+            cmds.extend(self.default_build_args)
         for mod, mconf in self.sitemods.get(subcommand, {}).items():
             if 'cli_arg' not in mconf:
                 continue


### PR DESCRIPTION
Addresses https://github.com/NERSC/podman-hpc/issues/66

Basically just removing the two lines that were treaing the `build` subcommand differently.

I tested on Muller and this appears to give the behavior we want.

`
stephey@nid001012:/mscratch/sd/s/stephey/containerfiles/test> podman-hpc build -t test:test . --log-level=debug
`
end of output:

`
DEBU[0000] Called build.PersistentPostRunE(/usr/bin/podman build --root /tmp/75313_hpc/storage --runroot /tmp/75313_hpc --storage-opt additionalimagestore=/mscratch/sd/s/stephey/storage --storage-opt mount_program=/usr/bin/fuse-overlayfs-wrap --storage-opt ignore_chown_errors=true --cgroup-manager cgroupfs --log-level fatal -t test:test . --log-level=debug) 
`

This change should finally allow podman-hpc builds to work on the compute nodes!

```
stephey@nid001012:/mscratch/sd/s/stephey/containerfiles/test> podman-hpc build -t test:test . --no-cache
STEP 1/2: FROM docker.io/ubuntu:latest
STEP 2/2: WORKDIR /opt
COMMIT test:test
--> 7641ac3a0cc
Successfully tagged localhost/test:test
7641ac3a0ccbd8e606d012f11987da6fd42643380edb1452e76fd2fe8a59f464
stephey@nid001012:/mscratch/sd/s/stephey/containerfiles/test> 
```