### PR TITLE
Fix for issue69

### DIFF
--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -22,7 +22,7 @@ if [ "$1" = "wait" ] ; then
     exit
 fi
 
-F=$(echo $@|sed 's/,upperdir.*//'|sed 's/.*lowerdir=//')
+F=$(echo $@|sed 's/,upperdir.*//'|sed 's/.*lowerdir=//'|sed 's/.*://')
 echo "In fow $F.squash" >> $LOG
 if [ -e "${F}.squash" ] ; then
 	echo "Mount suash $F" >> $LOG

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -229,8 +229,8 @@ class MigrateUtils:
     images = None
     podman_bin = "podman"
     mksq_bin = "mksquashfs.static"
-    mksq_options = ["-comp", "lz4"]
-    exclude_list = ["/sqout", "/mksq", "/proc", "/sys"]
+    mksq_options = ["-comp", "lz4", "-xattrs-exclude", "security.capability"]
+    exclude_list = ["/sqout", "/mksq", "/proc", "/sys", "/dev"]
     _mksq_inside = "/mksq"
 
     def __init__(self, src=None, dst=None, conf=None):


### PR DESCRIPTION
This addresses an issue when using --userns keep-id.  There are two issues that crop up.

1) including some devices files and security capabilities will
   cause keep-id to fail because it can't change the ownership
   or copy the files
2) the fuse mount gets called twice and one of the calls does
   an extra overlay which the wrapper didn't handle.