### PR TITLE
speed up gpu module by converting from copy to bind

### DIFF
--- a/etc/modules.d/gpu.yaml
+++ b/etc/modules.d/gpu.yaml
@@ -6,11 +6,11 @@ additional_args:
   - -e NVIDIA_VISIBLE_DEVICES
 copy:
   - ../01-gpu.conf:/etc/ld.so.conf.d/02-gpu.conf
+bind:
   - /usr/lib64/libnv*:/usr/lib64/
   - /usr/lib64/nvidia/libOpenCL*:/usr/lib64/
   - /usr/lib64/libcuda*:/usr/lib64/
   - /opt/cray/pe/mpich/default/gtl/lib/libmpi_gtl_cuda*:/usr/lib64/
-bind:
   - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi
   - /dev/nvidiactl:/dev/nvidiactl
   - /dev/nvidia*:/dev/


### PR DESCRIPTION
Try to address https://github.com/NERSC/podman-hpc/issues/51

Looks like it shaves off about 2 seconds from startup

Test on muller:

```
stephey@nid001036:~> time podman-hpc run --rm --gpu nvcr.io/nvidia/pytorch:23.05-py3 date
```

With copy:

```
real	0m4.126s
user	0m0.331s
sys	0m0.109s
```

With bind:

```
real	0m2.037s
user	0m0.318s
sys	0m0.124s
stephey@nid001036:~> 
```