### PR TITLE
update default build args, make pull use them

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -163,11 +163,11 @@ def rmsqi(siteconf, image):
 @click.pass_context
 @click.argument("podman_args", nargs=-1, type=click.UNPROCESSED)
 @click.argument("image")
-def pull(ctx, siteconf, image, podman_args):
+def pull(ctx, siteconf, image, podman_args, **site_opts):
     """Pulls an image to a local repository and makes a squashed copy."""
     cmd = [siteconf.podman_bin, "pull"]
     cmd.extend(podman_args)
-    cmd.extend(siteconf.default_pull_args)
+    cmd.extend(siteconf.get_cmd_extensions("pull", site_opts))
     cmd.append(image)
     proc = Popen(cmd)
     proc.communicate()
@@ -178,7 +178,6 @@ def pull(ctx, siteconf, image, podman_args):
     else:
         sys.stderr.write("Pull failed.\n")
         sys.exit(proc.returncode)
-
 
 # podman-hpc shared-run subcommand #########################################
 @podhpc.command(

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -95,13 +95,18 @@ class SiteConfig:
             self._check_and_set(param)
 
         self.read_site_modules()
+
+        if isinstance(self.wait_poll_interval, str):
+            self.wait_poll_interval = \
+                float(self.wait_poll_interval)
+        if isinstance(self.wait_timeout, str):
+            self.wait_timeout = float(self.wait_timeout)
+
         # TODO: Allow this to be over-rideable
         if len(self.default_args) == 0:
             self.default_args = [
                     "--root", self.graph_root,
                     "--runroot", self.run_root,
-                    "--storage-opt",
-                    f"additionalimagestore={self.additionalimagestore()}",
                     "--storage-opt",
                     f"mount_program={self.mount_program}",
                     "--storage-opt",
@@ -110,32 +115,19 @@ class SiteConfig:
                     ]
         if len(self.default_run_args) == 0:
             self.default_run_args = [
+                    "--storage-opt",
+                    f"additionalimagestore={self.additionalimagestore()}",
                     "--hooks-dir", self.hooks_dir,
-                    "-e", f"{_MOD_ENV}={self.modules_dir}",
+                    "--env", f"{_MOD_ENV}={self.modules_dir}",
                     "--annotation", f"{_HOOKS_ANNO}=true",
                     "--security-opt", "seccomp=unconfined",
                     ]
-        if isinstance(self.wait_poll_interval, str):
-            self.wait_poll_interval = \
-                float(self.wait_poll_interval)
-        if isinstance(self.wait_timeout, str):
-            self.wait_timeout = float(self.wait_timeout)
-        if len(self.default_pull_args) == 0:
-            self.default_pull_args = [
-                    "--root", self.graph_root,
-                    "--runroot", self.run_root,
-                    "--cgroup-manager", "cgroupfs",
-                    ]
         if len(self.default_build_args) == 0:
             self.default_build_args = [
-                    "--root", self.graph_root,
-                    "--runroot", self.run_root,
-                    "--storage-opt",
-                    f"mount_program={self.mount_program}",
-                    "--storage-opt",
-                    "ignore_chown_errors=true",
-                    "--cgroup-manager", "cgroupfs",
-                    ]            
+                    "--hooks-dir", self.hooks_dir,
+                    "--env", f"{_MOD_ENV}={self.modules_dir}",
+                    "--annotation", f"{_HOOKS_ANNO}=true",
+                    ]
         self.log_level = log_level
 
     def dump_config(self):
@@ -349,6 +341,10 @@ class SiteConfig:
             cmds.extend(self.default_run_args)
         elif subcommand == "build":
             cmds.extend(self.default_build_args)
+        elif subcommand == "pull":
+            cmds.extend(self.default_pull_args)
+        else:
+            pass
         for mod, mconf in self.sitemods.get(subcommand, {}).items():
             if 'cli_arg' not in mconf:
                 continue

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -32,8 +32,7 @@ class SiteConfig:
                      "localid_var", "tasks_per_node_var", "ntasks_pattern",
                      "config_home", "mksquashfs_bin",
                      "wait_timeout", "wait_poll_interval",
-                     "use_default_args", "use_default_run_args",
-                     "use_default_pull_args", "use_default_build_args"
+                     "use_default_args",
                      ]
     _valid_templates = ["shared_run_args_template",
                         "graph_root_template",
@@ -54,9 +53,6 @@ class SiteConfig:
     modules_dir = "/etc/podman_hpc/modules.d"
     shared_run_exec_args = ["-e", "SLURM_*", "-e", "PALS_*", "-e", "PMI_*"]
     use_default_args = True
-    use_default_run_args = True
-    use_default_pull_args = True
-    use_default_build_args = True
     shared_run_command = ["sleep", "infinity"]
     podman_bin = "podman"
     mount_program = "fuse-overlayfs-wrap"
@@ -108,14 +104,11 @@ class SiteConfig:
                     "--runroot", self.run_root,
                     "--storage-opt",
                     f"mount_program={self.mount_program}",
-                    "--storage-opt",
-                    "ignore_chown_errors=true",
                     "--cgroup-manager", "cgroupfs",
                     ]
-        else:
-            self.default_args = []
-        if self.use_default_run_args is True:
             self.default_run_args = [
+                    "--storage-opt",
+                    "ignore_chown_errors=true",                    
                     "--storage-opt",
                     f"additionalimagestore={self.additionalimagestore()}",
                     "--hooks-dir", self.hooks_dir,
@@ -123,20 +116,21 @@ class SiteConfig:
                     "--annotation", f"{_HOOKS_ANNO}=true",
                     "--security-opt", "seccomp=unconfined",
                     ]
-        else:
-            self.default_run_args = []
-        if self.use_default_build_args is True:
             self.default_build_args = [
                     "--hooks-dir", self.hooks_dir,
                     "--env", f"{_MOD_ENV}={self.modules_dir}",
                     "--annotation", f"{_HOOKS_ANNO}=true",
                     ]
+            self.default_pull_args = [
+                    "--storage-opt",
+                    "ignore_chown_errors=true",
+                    ]
         else:
+            self.default_args = []
+            self.default_run_args = []
             self.default_build_args = []
+            self.default_pull_args = []
         
-        #currently no additional pull args, but they could be added
-        self.default_pull_args = []
-
         self.log_level = log_level
 
     def dump_config(self):


### PR DESCRIPTION
Addresses 

https://github.com/NERSC/podman-hpc/issues/81

https://github.com/NERSC/podman-hpc/issues/80

https://github.com/NERSC/podman-hpc/issues/76 

Adjusts the base set of default args. Forces `pull` to use the default args (it wasn't before, and was ignoring log-level) and append extra args as needed. More in line with how `shared_run` was already handling args. 

Have completed some preliminary testing on Muller- looks ok so far. 

For example, from build:

`
DEBU[0037] Called build.PersistentPostRunE(/usr/bin/podman build --root /tmp/75313_hpc/storage --runroot /tmp/75313_hpc --storage-opt mount_program=/usr/bin/fuse-overlayfs-wrap --storage-opt ignore_chown_errors=true --cgroup-manager cgroupfs --hooks-dir /usr/share/containers/oci/hooks.d --env PODMANHPC_MODULES_DIR=/etc/podman_hpc/modules.d --annotation podman_hpc.hook_tool=true --log-level debug -t test:test .)
`

From pull:

`
DEBU[0001] Called pull.PersistentPostRunE(/usr/bin/podman pull --root /tmp/75313_hpc/storage --runroot /tmp/75313_hpc --storage-opt mount_program=/usr/bin/fuse-overlayfs-wrap --storage-opt ignore_chown_errors=true --cgroup-manager cgroupfs --log-level debug ubuntu:latest) 
INFO: Migrating image to /mscratch/sd/s/stephey/storage
`

From run:

`
time="2023-07-28T15:02:20-07:00" level=debug msg="Called run.PersistentPostRunE(/usr/bin/podman run --root /tmp/75313_hpc/storage --runroot /tmp/75313_hpc --storage-opt mount_program=/usr/bin/fuse-overlayfs-wrap --storage-opt ignore_chown_errors=true --cgroup-manager cgroupfs --storage-opt additionalimagestore=/mscratch/sd/s/stephey/storage --hooks-dir /usr/share/containers/oci/hooks.d --env PODMANHPC_MODULES_DIR=/etc/podman_hpc/modules.d --annotation podman_hpc.hook_tool=true --security-opt seccomp=unconfined --log-level debug --rm registry.nersc.gov/library/nersc/mpi4py:3.1.3 date)"
`