### PR TITLE
add images command for additionalimagestore

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -151,6 +151,15 @@ def rmsqi(siteconf, image):
     mu = MigrateUtils(conf=siteconf)
     mu.remove_image(image)
 
+# podman-hpc images subcommand #############################################
+@pass_siteconf
+@click.pass_context
+@click.argument("podman_args", nargs=-1, type=click.UNPROCESSED)
+def images(ctx, siteconf, image, podman_args, **site_opts):
+    """Displays images in both local and additionalimagestore."""
+    cmd = [siteconf.podman_bin, "images"]
+    cmd.extend(podman_args)
+    cmd.extend(siteconf.get_cmd_extensions("images", site_opts))
 
 # podman-hpc pull subcommand (modified) ####################################
 @podhpc.command(

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -125,11 +125,16 @@ class SiteConfig:
                     "--storage-opt",
                     "ignore_chown_errors=true",
                     ]
+            self.default_images_args = [
+                    "--storage-opt",
+                    f"additionalimagestore={self.additionalimagestore()}",
+                    ]
         else:
             self.default_args = []
             self.default_run_args = []
             self.default_build_args = []
             self.default_pull_args = []
+            self.default_images_args = []
         
         self.log_level = log_level
 
@@ -346,6 +351,8 @@ class SiteConfig:
             cmds.extend(self.default_build_args)
         elif subcommand == "pull":
             cmds.extend(self.default_pull_args)
+        elif subcommand == "images":
+            cmds.extend(self.default_images_args)
         else:
             pass
         for mod, mconf in self.sitemods.get(subcommand, {}).items():


### PR DESCRIPTION
Should address https://github.com/NERSC/podman-hpc/issues/87

Instead of adding and then removing additionalimagestore from the defaults, I just created a separate `images` command. I thought this would be a cleaner way to handle the problem. 

Have done some basic testing in a muller reservation and standard behavior (pull, build, run) seems ok.

```
stephey@nid001003:/mscratch/sd/s/stephey/podman-hpc/podman_hpc> podman-hpc images
REPOSITORY                TAG         IMAGE ID      CREATED         SIZE        R/O
localhost/test            test        b0bfc82c60de  12 minutes ago  550 MB      false
localhost/test            test1       841451f9dbb7  8 days ago      80.4 MB     true
localhost/test            test        61b85dc0093d  8 days ago      550 MB      true
docker.io/library/ubuntu  latest      c6b84b685f35  6 weeks ago     80.4 MB     false
docker.io/library/ubuntu  latest      c6b84b685f35  6 weeks ago     80.4 MB     true
docker.io/library/ubuntu  focal       6df894023726  8 weeks ago     75.2 MB     false
docker.io/library/ubuntu  focal       6df894023726  8 weeks ago     75.2 MB     true
```

