### PR TITLE
prep for 1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2023-10-02
+
+This is a minor release that fixes a bug.
+
+- Fixes bug where squashed images in the additionalimagestore were not displayed by the `podman-hpc images` command (#87)
+
 ## [1.0.3] - 2023-09-01
 
 This is a minor release that fixes several bugs.

--- a/podman-hpc.spec
+++ b/podman-hpc.spec
@@ -14,7 +14,7 @@
 
 
 Name:           podman-hpc
-Version:        1.0.3
+Version:        1.0.4
 Release:        1
 Summary:	Scripts to enable Podman to run in an HPC environment
 # FIXME: Select a correct license from https://github.com/openSUSE/spec-cleaner#spdx-licenses

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman-hpc
-version = 1.0.3
+version = 1.0.4
 
 [options]
 packages = podman_hpc


### PR DESCRIPTION
Bumps version number in `podman-hpc.spec` and in `setup.cfg`

Adds notes in CHANGELOG 