### PR TITLE
remove newline replace to fix formatting of help options

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -350,10 +350,7 @@ def call_podman(ctx, siteconf, help, podman_args, **site_opts):
         app_options = ""
         if formatter.getvalue():
             app_options = (
-                f"{app_name.capitalize()} {formatter.getvalue()}\n".replace(
-                    "\n", "\\n"
-                )
-            )
+                f"{app_name.capitalize()} {formatter.getvalue()}\n")
 
         cmd = [siteconf.podman_bin, ctx.info_name, "--help"]
         proc = Popen(cmd, env=siteconf.env, stdout=PIPE)


### PR DESCRIPTION
Addresses https://github.com/NERSC/podman-hpc/issues/77

It looks like we had an unnecessary newline replace with a double escape. I took it out and tested and it looks ok.

Without fix:

```
stephey@alvarez:login01:~> podman-hpc run --help
Run a command in a new container

Description:
  Runs a command in a new container from the given image

Usage:
  podman-hpc run [options] IMAGE [COMMAND [ARG...]]

Examples:
  podman-hpc run imageID ls -alF /etc
  podman-hpc run --network=host imageID dnf -y install java
  podman-hpc run --volume /var/hostdir:/var/ctrdir -i -t fedora /bin/bash

Podman-hpc Options:\n  --cuda-mpi  Enable CUDA-aware Cray MPICH Support\n  --cvmfs     Enable cmvfs filesystem\n  --gpu       Enable NVIDIA GPU Support\n  --mpi       Enable Cray MPICH Support\n  --nccl      Enable SS11 support for NCCL\n\nPodman options follow:
      --add-host strings                         Add a custom host-to-IP mapping (host:ip) (default [])
      --annotation strings                       Add annotations to container (key=value)
      --arch ARCH                                use ARCH instead of the architecture of the machine for choosing images
  -a, --attach strings                           Attach to STDIN, STDOUT or STDERR
```

With fix:

```
stephey@nid200000:~> podman-hpc run --help
Run a command in a new container

Description:
  Runs a command in a new container from the given image

Usage:
  podman-hpc run [options] IMAGE [COMMAND [ARG...]]

Examples:
  podman-hpc run imageID ls -alF /etc
  podman-hpc run --network=host imageID dnf -y install java
  podman-hpc run --volume /var/hostdir:/var/ctrdir -i -t fedora /bin/bash

Podman-hpc Options:
  --cuda-mpi  Enable CUDA-aware Cray MPICH Support
  --cvmfs     Enable cmvfs filesystem
  --gpu       Enable NVIDIA GPU Support
  --mpi       Enable Cray MPICH Support
  --nccl      Enable SS11 support for NCCL

Podman options follow:
      --add-host strings                         Add a custom host-to-IP mapping (host:ip) (default [])
      --annotation strings                       Add annotations to container (key=value)
      --arch ARCH                                use ARCH instead of the architecture of the machine for choosing images
  -a, --attach strings                           Attach to STDIN, STDOUT or STDERR
```