### PR TITLE
add openmpi helper and prepare for release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2023-11-09
+## [1.1.0] - 2023-11-12
 
 This is a minor release. It adds initial support for OpenMPI4/PMI2 and OpenMPI5/PMIx.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2023-11-09
+
+This is a minor release. It adds support for OpenMPI4 and older using PMI2. Future
+work will be needed to support OpenMPI5 and PMIx.
+
+- Adds ability to pass through file descriptors needed for PMI2 (#95)
+
 ## [1.0.4] - 2023-10-02
 
 This is a minor release that fixes a bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.5] - 2023-11-09
 
-This is a minor release. It adds support for OpenMPI4 and older using PMI2. Future
-work will be needed to support OpenMPI5 and PMIx.
+This is a minor release. It adds initial support for OpenMPI4/PMI2 and OpenMPI5/PMIx.
 
 - Adds ability to pass through file descriptors needed for PMI2 (#95)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.5] - 2023-11-09
+## [1.1.0] - 2023-11-09
 
 This is a minor release. It adds initial support for OpenMPI4/PMI2 and OpenMPI5/PMIx.
 
@@ -13,20 +13,20 @@ This is a minor release. It adds initial support for OpenMPI4/PMI2 and OpenMPI5/
 
 ## [1.0.4] - 2023-10-02
 
-This is a minor release that fixes a bug.
+This is a patch release that fixes a bug.
 
 - Fixes bug where squashed images in the additionalimagestore were not displayed by the `podman-hpc images` command (#87)
 
 ## [1.0.3] - 2023-09-01
 
-This is a minor release that fixes several bugs.
+This is a patch release that fixes several bugs.
 
 - Fixes issue using userns keep-id for squashed images (#83)
 - Fixes inconsistencies in pull, build, and run settings (#81, #80, #76). Makes it possible for users to override default settings and provide their own.
 
 ## [1.0.2] - 2023-06-15
 
-This is a minor release that fixes several additional bugs.
+This is a patch release that fixes several additional bugs.
 
 - Fixes issue that causes unclean exit from leftover mounts, contributed by Pat Tovo at HPE (#54)
 - Fixes issue that causes problems with keepid during image squash (#69)
@@ -36,7 +36,7 @@ This is a minor release that fixes several additional bugs.
 
 ## [1.0.1] - 2023-03-17
 
-This is a minor release that fixes several bugs that have been found in early testing.
+This is a patch release that fixes several bugs that have been found in early testing.
 
 ### Bugfixes
 

--- a/etc/modules.d/openmpi-pmi2.yaml
+++ b/etc/modules.d/openmpi-pmi2.yaml
@@ -1,0 +1,22 @@
+name: openmpi-pmi2
+cli_arg: openmpi-pmi2
+help: Enable OpenMPI/PMI2 Support
+env: ENABLE_OPENMPI_PMI2
+shared_run: True
+additional_args:
+  - -e SLURM_*
+  - -e PALS_*
+  - -e PMI_*
+  - --ipc=host
+  - --network=host
+  - --pid=host
+  - --privileged
+bind:
+  - /dev/xpmem:/dev/xpmem
+  - /dev/shm:/dev/shm
+  - /dev/ss0:/dev/ss0
+  - /dev/cxi*:/dev/
+  - /var/spool/slurmd:/var/spool/slurmd
+  - /run/munge:/run/munge
+  - /run/nscd:/run/nscd
+  - /etc/libibverbs.d:/etc/libibverbs.d

--- a/etc/modules.d/openmpi-pmix.yaml
+++ b/etc/modules.d/openmpi-pmix.yaml
@@ -1,12 +1,15 @@
-name: openmpi
-cli_arg: openmpi
-help: Enable OpenMPI Support
-env: ENABLE_OPENMPI
-shared_run: True
+name: openmpi-pmix
+cli_arg: openmpi-pmix
+help: Enable OpenMPI/PMIx Support
+env: ENABLE_OPENMPI_PMIX
+shared_run: False
 additional_args:
+  - --userns=keep-id
   - -e SLURM_*
+  - -e SLURMD_*
   - -e PALS_*
   - -e PMI_*
+  - -e PMIX_*
   - --ipc=host
   - --network=host
   - --pid=host

--- a/etc/modules.d/openmpi.yaml
+++ b/etc/modules.d/openmpi.yaml
@@ -1,0 +1,22 @@
+name: openmpi
+cli_arg: openmpi
+help: Enable OpenMPI Support
+env: ENABLE_OPENMPI
+shared_run: True
+additional_args:
+  - -e SLURM_*
+  - -e PALS_*
+  - -e PMI_*
+  - --ipc=host
+  - --network=host
+  - --pid=host
+  - --privileged
+bind:
+  - /dev/xpmem:/dev/xpmem
+  - /dev/shm:/dev/shm
+  - /dev/ss0:/dev/ss0
+  - /dev/cxi*:/dev/
+  - /var/spool/slurmd:/var/spool/slurmd
+  - /run/munge:/run/munge
+  - /run/nscd:/run/nscd
+  - /etc/libibverbs.d:/etc/libibverbs.d

--- a/podman-hpc.spec
+++ b/podman-hpc.spec
@@ -14,7 +14,7 @@
 
 
 Name:           podman-hpc
-Version:        1.0.4
+Version:        1.0.5
 Release:        1
 Summary:	Scripts to enable Podman to run in an HPC environment
 # FIXME: Select a correct license from https://github.com/openSUSE/spec-cleaner#spdx-licenses

--- a/podman-hpc.spec
+++ b/podman-hpc.spec
@@ -14,7 +14,7 @@
 
 
 Name:           podman-hpc
-Version:        1.0.5
+Version:        1.1.0
 Release:        1
 Summary:	Scripts to enable Podman to run in an HPC environment
 # FIXME: Select a correct license from https://github.com/openSUSE/spec-cleaner#spdx-licenses

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman-hpc
-version = 1.0.4
+version = 1.0.5
 
 [options]
 packages = podman_hpc
@@ -29,4 +29,5 @@ console_scripts =
       etc/modules.d/cuda-mpich.yaml
       etc/modules.d/nccl.yaml
       etc/modules.d/cvmfs.yaml
+      etc/modules.d/openmpi.yaml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman-hpc
-version = 1.0.5
+version = 1.1.0
 
 [options]
 packages = podman_hpc

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,5 +29,6 @@ console_scripts =
       etc/modules.d/cuda-mpich.yaml
       etc/modules.d/nccl.yaml
       etc/modules.d/cvmfs.yaml
-      etc/modules.d/openmpi.yaml
+      etc/modules.d/openmpi-pmi2.yaml
+      etc/modules.d/openmpi-pmix.yaml
 


### PR DESCRIPTION
Adds an openmpi helper module to make using openmpi with slurm pmi2 easier

Note we'll need a corresponding openmpi module MR in the nersc internal ansible config 

Updates files for release 1.1.0