### PR TITLE
Add initial delay and scale wait parameters with ntasks

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import math
 import socket
 import re
 import time
@@ -12,6 +13,14 @@ from .migrate2scratch import ImageStore
 from .siteconfig import SiteConfig
 from multiprocessing import Process
 from subprocess import Popen, PIPE
+
+
+def _round_nearest(x, a):
+    return round(x / a) * a
+
+
+def _param_scale_log2(x, p):
+    return _round_nearest(p*(1 + math.log2(x)), p)
 
 
 def podman_devnull(cmd, conf):
@@ -309,11 +318,14 @@ def _shared_run(conf, run_args, **site_opts):
     try:
         # wait for container to exist
         comm = ["container", "exists", container_name]
-        time.sleep(conf.wait_poll_interval)
         start_time = time.time()
-        while podman_devnull(comm, conf) != 0:
-            time.sleep(conf.wait_poll_interval)
-            if time.time() - start_time > conf.wait_timeout:
+        wait_poll_interval = _param_scale_log2(ntasks, conf.wait_poll_interval)
+        wait_timeout = _param_scale_log2(ntasks, conf.wait_timeout)
+        while True:
+            time.sleep(wait_poll_interval)
+            if podman_devnull(comm, conf) == 0:
+                break
+            if time.time() - start_time > wait_timeout:
                 msg = "Timeout waiting for shared-run start"
                 raise OSError(msg)
             if run_thread and run_thread.exitcode:

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -309,6 +309,7 @@ def _shared_run(conf, run_args, **site_opts):
     try:
         # wait for container to exist
         comm = ["container", "exists", container_name]
+        time.sleep(conf.wait_poll_interval)
         start_time = time.time()
         while podman_devnull(comm, conf) != 0:
             time.sleep(conf.wait_poll_interval)


### PR DESCRIPTION
This PR makes a few adjustments to help with shared run startup at "high" concurrency per node.

The `wait_timeout` and `wait_poll_interval` parameters are log2 scaled with `ntasks` (note this is "number of tasks per node").

For example, with `wait_timeout=10` and `wait_poll_interval=0.2`:

ntasks | wait_timeout | wait_poll_interval
--- | --- | ---
1 | 10 | 0.2
2 | 20 | 0.4
4 | 30 | 0.6
8 | 40 | 0.8
16 | 50 | 1.0
32 | 60 | 1.2
64 | 70 | 1.4
128 | 80 | 1.6
256 | 90 | 1.8

Also, the wait poll loop is converted to a "do-loop" style which includes an initial wait before checking for the existence of the container to give the container a chance to start up before polling for it's existence.

