### PR TITLE
add modules to conveniently mount various directories

### DIFF
--- a/etc/modules.d/cfs.yaml
+++ b/etc/modules.d/cfs.yaml
@@ -1,0 +1,6 @@
+name: cfs
+cli_arg: cfs
+help: Mount CFS
+env: MOUNT_CFS
+bind:
+  - $CFS:$CFS

--- a/etc/modules.d/home.yaml
+++ b/etc/modules.d/home.yaml
@@ -1,0 +1,6 @@
+name: home
+cli_arg: home
+help: Mount home directory
+env: MOUNT_HOME
+bind:
+  - $HOME:$HOME

--- a/etc/modules.d/jupyter.yaml
+++ b/etc/modules.d/jupyter.yaml
@@ -1,0 +1,7 @@
+name: jupyter
+cli_arg: jupyter
+help: Mount /tmp and home for Jupyter use
+env: MOUNT_JUPYTER
+bind:
+  - /tmp:/tmp
+  - $HOME:$HOME

--- a/etc/modules.d/scratch.yaml
+++ b/etc/modules.d/scratch.yaml
@@ -1,0 +1,6 @@
+name: scratch
+cli_arg: scratch
+help: Mount scratch directory
+env: MOUNT_SCRATCH
+bind:
+  - $SCRATCH:$SCRATCH

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ console_scripts =
       etc/modules.d/home.yaml
       etc/modules.d/scratch.yaml
       etc/modules.d/cfs.yaml
+      etc/modules.d/jupyter.yaml
       etc/modules.d/gpu.yaml
       etc/modules.d/mpich.yaml
       etc/modules.d/cuda-mpich.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ console_scripts =
       etc/01-cvmfs.conf
       etc/podman_hpc.yaml
     etc/podman_hpc/modules.d =
+      etc/modules.d/home.yaml
+      etc/modules.d/scratch.yaml
+      etc/modules.d/cfs.yaml
       etc/modules.d/gpu.yaml
       etc/modules.d/mpich.yaml
       etc/modules.d/cuda-mpich.yaml


### PR DESCRIPTION
adds modules to mount `$HOME`, `$SCRATCH`, and `$CFS`. also adds a module to mount `/tmp:/tmp` and `$HOME:HOME` together for Jupyter use; these are necessary for a podman-hpc kernel to connect to its server.