### PR TITLE
Enable Transport Prefixes

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -207,6 +207,12 @@ def images(ctx, siteconf, image, podman_args, **site_opts):
 @click.argument("image")
 def pull(ctx, siteconf, image, podman_args, **site_opts):
     """Pulls an image to a local repository and makes a squashed copy."""
+    # Check for transport_prefix
+    if "://" in image:
+        transport_prefix, image = image.split("://", 1)
+    else:
+        transport_prefix = None
+    
     cmd = [siteconf.podman_bin, "pull"]
     cmd.extend(podman_args)
     cmd.extend(siteconf.get_cmd_extensions("pull", site_opts))

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -206,19 +206,20 @@ def images(ctx, siteconf, image, podman_args, **site_opts):
 @click.argument("podman_args", nargs=-1, type=click.UNPROCESSED)
 @click.argument("image")
 def pull(ctx, siteconf, image, podman_args, **site_opts):
-    """Pulls an image to a local repository and makes a squashed copy."""
-    # Check for transport_prefix
-    if "://" in image:
-        transport_prefix, image = image.split("://", 1)
-    else:
-        transport_prefix = None
-    
+    """Pulls an image to a local repository and makes a squashed copy."""    
     cmd = [siteconf.podman_bin, "pull"]
     cmd.extend(podman_args)
     cmd.extend(siteconf.get_cmd_extensions("pull", site_opts))
     cmd.append(image)
     proc = Popen(cmd)
     proc.communicate()
+
+    # Check for transport_prefix
+    if "://" in image:
+        transport_prefix, image = image.split("://", 1)
+    else:
+        transport_prefix = None
+
     if proc.returncode == 0:
         sys.stdout.write(f"INFO: Migrating image to {siteconf.squash_dir}\n")
         mu = MigrateUtils(conf=siteconf)


### PR DESCRIPTION
There isn't a `CONTRIB.md` so I have created a fork and PR.

Closes #132. TLDR: enables `podman-hpc pull docker://docker.io/library/ubuntu:latest`.

I thought that simply adding this after the `podman pull` subprocess would do the job instead of updating `MigrateUtils()`.

```python
def pull(ctx, siteconf, image, podman_args, **site_opts):
    """Pulls an image to a local repository and makes a squashed copy."""    
    cmd = [siteconf.podman_bin, "pull"]
    cmd.extend(podman_args)
    cmd.extend(siteconf.get_cmd_extensions("pull", site_opts))
    cmd.append(image)
    proc = Popen(cmd)
    proc.communicate()

    # Check for transport_prefix
    if "://" in image:
        transport_prefix, image = image.split("://", 1)
    else:
        transport_prefix = None
```

- [ ] Do you reckon this is a good place for the check? Or should it be after `if proc.returncode == 0:`?
- [ ] Can you think of another Podman-HPC wrapped function that would be affected by transport prefixes?
- [ ] I don't currently have a dev environment for `podman-hpc`. If you would accept this change / or have feedback do let me know and I'll do some testing.