### PR TITLE
Module conflicts and dependencies

### DIFF
--- a/etc/modules.d/cuda-mpich.yaml
+++ b/etc/modules.d/cuda-mpich.yaml
@@ -2,6 +2,7 @@ name: cuda-mpi
 cli_arg: cuda-mpi
 help: Enable CUDA-aware Cray MPICH Support
 env: ENABLE_CUDA_MPICH_SS
+conflicts: ["mpich", "openmpi-pmi2", "openmpi-pmix"]
 shared_run: True
 additional_args:
   - -e SLURM_*

--- a/etc/modules.d/mpich.yaml
+++ b/etc/modules.d/mpich.yaml
@@ -2,6 +2,7 @@ name: mpich
 cli_arg: mpi
 help: Enable Cray MPICH Support
 env: ENABLE_MPICH_SS
+conflicts: ["cuda-mpi", "openmpi-pmi2", "openmpi-pmix"]
 shared_run: True
 additional_args:
   - -e SLURM_*

--- a/etc/modules.d/openmpi-pmi2.yaml
+++ b/etc/modules.d/openmpi-pmi2.yaml
@@ -2,6 +2,7 @@ name: openmpi-pmi2
 cli_arg: openmpi-pmi2
 help: Enable OpenMPI/PMI2 Support
 env: ENABLE_OPENMPI_PMI2
+conflicts: ["mpich", "cuda-mpi", "openmpi-pmix"]
 shared_run: True
 additional_args:
   - -e SLURM_*

--- a/etc/modules.d/openmpi-pmix.yaml
+++ b/etc/modules.d/openmpi-pmix.yaml
@@ -2,6 +2,7 @@ name: openmpi-pmix
 cli_arg: openmpi-pmix
 help: Enable OpenMPI/PMIx Support
 env: ENABLE_OPENMPI_PMIX
+conflicts: ["mpich", "cuda-mpi", "openmpi-pmi2"]
 shared_run: False
 additional_args:
   - --userns=keep-id

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import toml
 import re
+import warnings
 from yaml import load
 from yaml import FullLoader
 from copy import deepcopy
@@ -372,7 +373,7 @@ class SiteConfig:
                 for dep in mconf['depends_on']:
                     if dep not in enabled_modules:
                         dep_cli_arg = self.sitemods.get(subcommand, {}).get(dep, {}).get('cli_arg', dep)
-                        raise ValueError(
+                        warnings.warn(
                             f"Module '{mod}' (--{mconf['cli_arg']}) requires '{dep}' to be enabled. "
                             f"Please add --{dep_cli_arg} to your command."
                         )
@@ -382,7 +383,7 @@ class SiteConfig:
                 for conflict in mconf['conflicts']:
                     if conflict in enabled_modules:
                         conflict_cli_arg = self.sitemods.get(subcommand, {}).get(conflict, {}).get('cli_arg', conflict)
-                        raise ValueError(
+                        warnings.warn(
                             f"Module '{mod}' (--{mconf['cli_arg']}) conflicts with '{conflict}' (--{conflict_cli_arg}). "
                             f"These modules cannot be used together."
                         )

--- a/podman_hpc/siteconfig.py
+++ b/podman_hpc/siteconfig.py
@@ -370,7 +370,7 @@ class SiteConfig:
         original_formatwarning = warnings.formatwarning
         def format_warning(message, category, filename, lineno, line=None):
             """ custom formatter that only shows the message """
-            return f"{message}\n"
+            return f"WARNING: {message}\n"
         warnings.formatwarning = format_warning
 
         # Second pass: process enabled modules (dependencies, conflicts, and add command extensions)


### PR DESCRIPTION
Adds support for two new module YAML entries `depends_on` and `conflicts`.

Currently it only issues warnings to avoid breaking current usage but could be turned into errors in future releases.

* MPI modules to conflict with each other.
* `cuda-mpi` depends on `gpu`


```
(.venv) cookbg@muller:login07:~/src/podman-hpc> PODMANHPC_MODULES_DIR=./etc/modules.d podman-hpc run --rm --mpi --cuda-mpi hello-world
WARNING: Module 'cuda-mpi' (--cuda-mpi) conflicts with 'mpich' (--mpi). These modules cannot be used together.
WARNING: Module 'mpich' (--mpi) conflicts with 'cuda-mpi' (--cuda-mpi). These modules cannot be used together.
```

```
(.venv) cookbg@muller:login07:~/src/podman-hpc> PODMANHPC_MODULES_DIR=./etc/modules.d podman-hpc run --rm --cuda-mpi hello-world
WARNING: Module 'cuda-mpi' (--cuda-mpi) requires 'gpu' to be enabled. Please add --gpu to your command.
```

