### PR TITLE
Add support for inspect

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -194,6 +194,16 @@ def images(ctx, siteconf, image, podman_args, **site_opts):
     cmd.extend(podman_args)
     cmd.extend(siteconf.get_cmd_extensions("images", site_opts))
 
+# podman-hpc inspect subcommand #############################################
+@pass_siteconf
+@click.pass_context
+@click.argument("podman_args", nargs=-1, type=click.UNPROCESSED)
+def inspect(ctx, siteconf, image, podman_args, **site_opts):
+    """Displays images in both local and additionalimagestore."""
+    cmd = [siteconf.podman_bin, "inspect"]
+    cmd.extend(podman_args)
+    cmd.extend(siteconf.get_cmd_extensions("images", site_opts))
+
 # podman-hpc pull subcommand (modified) ####################################
 @podhpc.command(
     context_settings=dict(


### PR DESCRIPTION
Fixes #148. Currently, `podman-hpc inspect` does not look in `additionalimagestore` (e.g `$SCRATCH/storage`). I believe this is all that is necessary to add this behaviour.