### PR TITLE
mksquashfs.static: newer alpine, dependencies and selinux handling

### DIFF
--- a/extra/squash/Dockerfile
+++ b/extra/squash/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+FROM alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 
 RUN \
-   apk add zlib-dev git alpine-sdk zlib-static lz4-static lz4-dev
-
+   apk add zlib-dev git alpine-sdk zlib-static lz4-static lz4-dev \
+   lzo-dev xz-static xz-dev zstd-dev zstd-static sed
 RUN \
    git clone https://github.com/plougher/squashfs-tools && \
    cd squashfs-tools/squashfs-tools/ && \

--- a/extra/squash/Makefile
+++ b/extra/squash/Makefile
@@ -9,5 +9,5 @@ rpm: mksquashfs.static
 
 mksquashfs.static:
 	podman build -t mksq .
-	podman run -it --rm -v $(shell pwd):/d  mksq cp /usr/local/bin/mksquashfs /d/mksquashfs.static
+	podman run -it --rm -v $(shell pwd):/d:Z  mksq cp /usr/local/bin/mksquashfs /d/mksquashfs.static
 	


### PR DESCRIPTION
Hi there,
the `Dockerfile` and the `Makefile` provided to build and package `mksquashfs.static` did not work for me (opensuse 16 with selinux). In order to satisty the dependencies for newer `mksquashfs` versions I updated alpine and installed other packages. In `Makefile`, the `:Z` option appended to the mount in the `podman run` invocation handles Selinux labeling. 