### PR TITLE
Use `squashfuse_ll` when possible

### DIFF
--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -1,48 +1,50 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-LOG=/tmp/fow-$(id -u).log
-LOG=/dev/null
+set -u
 
-UMOUNT_WAIT_RETRIES=${UMOUNT_WAIT_RETRIES:-"5"}
-UMOUNT_WAIT_DELAY=${UMOUNT_WAIT_DELAY:-"1"}
+LOG="${LOG:-/dev/null}"
+UMOUNT_WAIT_RETRIES="${UMOUNT_WAIT_RETRIES:-5}"
+UMOUNT_WAIT_DELAY="${UMOUNT_WAIT_DELAY:-1}"
+FUSE_OVERLAYFS_BIN="${FUSE_OVERLAYFS_BIN:-/usr/bin/fuse-overlayfs}"
 
-if [ "$1" = "wait" ] ; then
-    inotifywait -e delete $2/etc
+if [[ -x /usr/bin/squashfuse_ll ]]; then
+    SQUASHFUSE_BIN="${SQUASHFUSE_BIN:-/usr/bin/squashfuse_ll}"
+else
+    SQUASHFUSE_BIN="${SQUASHFUSE_BIN:-/usr/bin/squashfuse}"
+fi
 
-    for i in $(seq $UMOUNT_WAIT_RETRIES); do
-        umount -v $3 >> $LOG 2>&1
-        if [ $? -ne 0 ]; then
-            # Sleep to let podman clean up
-            echo "Retry umount after sleep $UMOUNT_WAIT_DELAY second(s)" >> $LOG
-            sleep $UMOUNT_WAIT_DELAY
+if [[ "${1:-}" == "wait" ]]; then
+    inotifywait -e delete "$2/etc"
+
+    for i in $(seq "${UMOUNT_WAIT_RETRIES}"); do
+        umount -v "$3" >> "${LOG}" 2>&1
+        if [[ $? -ne 0 ]]; then
+            echo "Retry umount after sleep ${UMOUNT_WAIT_DELAY} second(s)" >> "${LOG}"
+            sleep "${UMOUNT_WAIT_DELAY}"
         else
             break
         fi
     done
-    exit
+    exit 0
 fi
 
-F=$(echo $@|sed 's/,upperdir.*//'|sed 's/.*lowerdir=//'|sed 's/.*://')
-echo "In fow $F.squash" >> $LOG
-if [ -e "${F}.squash" ] ; then
-        echo "Mount squash $F" >> $LOG
-        /usr/bin/squashfuse $F.squash $F >> $LOG 2>&1
+ARGS="$*"
+F="$(echo "${ARGS}" | sed 's/,upperdir.*//' | sed 's/.*lowerdir=//' | sed 's/.*://')"
+echo "In fow ${F}.squash" >> "${LOG}"
+if [[ -e "${F}.squash" ]]; then
+    echo "Mount squash ${F} with ${SQUASHFUSE_BIN}" >> "${LOG}"
+    "${SQUASHFUSE_BIN}" "${F}.squash" "${F}" >> "${LOG}" 2>&1
 fi
 
-#echo "Doing fuse mount" >> $LOG
-/usr/bin/fuse-overlayfs $@ >> $LOG 2>&1
+"${FUSE_OVERLAYFS_BIN}" "$@" >> "${LOG}" 2>&1
 RET=$?
-D=$(echo $@|sed 's/.* //')
-chmod a+rx ${D}
-echo "$D" >> $LOG
-ls -ld $D >> $LOG
+D="$(echo "${ARGS}" | sed 's/.* //')"
+chmod a+rx "${D}"
+echo "${D}" >> "${LOG}"
+ls -ld "${D}" >> "${LOG}"
 
-# Start a process to watch the mount and unmount squash
-# if possible
-if [ -e "${F}.squash" ] ; then
-        D=$(echo $@|sed 's/.* //')
-        $0 wait $D $F  0<&- &>/dev/null &
+if [[ -e "${F}.squash" ]]; then
+    "$0" wait "${D}" "${F}" 0<&- &>/dev/null &
 fi
 
-#sleep infinity
-exit $RET
+exit "${RET}"

--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -u
 
@@ -38,13 +38,13 @@ fi
 
 "${FUSE_OVERLAYFS_BIN}" "$@" >> "${LOG}" 2>&1
 RET=$?
-D="$(echo "${ARGS}" | sed 's/.* //')"
-chmod a+rx "${D}"
-echo "${D}" >> "${LOG}"
-ls -ld "${D}" >> "${LOG}"
+mount_dir="$(echo "${ARGS}" | sed 's/.* //')"
+chmod a+rx "${mount_dir}"
+echo "${mount_dir}" >> "${LOG}"
+ls -ld "${mount_dir}" >> "${LOG}"
 
 if [[ -e "${F}.squash" ]]; then
-    "$0" wait "${D}" "${F}" 0<&- &>/dev/null &
+    "$0" wait "${mount_dir}" "${F}" 0<&- &>/dev/null &
 fi
 
 exit "${RET}"

--- a/bin/fuse-overlayfs-wrap
+++ b/bin/fuse-overlayfs-wrap
@@ -28,23 +28,23 @@ if [[ "${1:-}" == "wait" ]]; then
     exit 0
 fi
 
-ARGS="$*"
-F="$(echo "${ARGS}" | sed 's/,upperdir.*//' | sed 's/.*lowerdir=//' | sed 's/.*://')"
-echo "In fow ${F}.squash" >> "${LOG}"
-if [[ -e "${F}.squash" ]]; then
-    echo "Mount squash ${F} with ${SQUASHFUSE_BIN}" >> "${LOG}"
-    "${SQUASHFUSE_BIN}" "${F}.squash" "${F}" >> "${LOG}" 2>&1
+args="$*"
+lowerdir_path="$(echo "${args}" | sed 's/,upperdir.*//' | sed 's/.*lowerdir=//' | sed 's/.*://')"
+echo "In fow ${lowerdir_path}.squash" >> "${LOG}"
+if [[ -e "${lowerdir_path}.squash" ]]; then
+    echo "Mount squash ${lowerdir_path} with ${SQUASHFUSE_BIN}" >> "${LOG}"
+    "${SQUASHFUSE_BIN}" "${lowerdir_path}.squash" "${lowerdir_path}" >> "${LOG}" 2>&1
 fi
 
 "${FUSE_OVERLAYFS_BIN}" "$@" >> "${LOG}" 2>&1
-RET=$?
-mount_dir="$(echo "${ARGS}" | sed 's/.* //')"
+ret=$?
+mount_dir="$(echo "${args}" | sed 's/.* //')"
 chmod a+rx "${mount_dir}"
 echo "${mount_dir}" >> "${LOG}"
 ls -ld "${mount_dir}" >> "${LOG}"
 
-if [[ -e "${F}.squash" ]]; then
-    "$0" wait "${mount_dir}" "${F}" 0<&- &>/dev/null &
+if [[ -e "${lowerdir_path}.squash" ]]; then
+    "$0" wait "${mount_dir}" "${lowerdir_path}" 0<&- &>/dev/null &
 fi
 
-exit "${RET}"
+exit "${ret}"


### PR DESCRIPTION
This is to address #156.

When `squashfuse_ll` is available under `/usr/bin`, the wrapper script will use that instead of the single-threaded `/usr/bin/squashfuse`. The path to the binary could be overwritten by setting the environment variable `SQUASHFUSE_BIN`.

I also cleaned up the previous script a little bit, and added `FUSE_OVERLAYFS_BIN` in case we want to overwrite that too.