### PR TITLE
make image migration supporting multiple tags for the same image

### DIFF
--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import json
+from shutil import rmtree
 from shutil import copytree, copy, which
 from subprocess import Popen, PIPE
 import logging
@@ -270,6 +271,50 @@ class ImageStore:
             logging.debug(f"Updated {self.images_json}")
             self.refresh()
 
+    def remove_image_tag(self, img_id, tag):
+        """
+        Remove a tag from an image record.
+
+        Returns the updated record, or None when the image record no longer
+        has any tag history and should be fully deleted.
+        """
+        if self.read_only:
+            raise ValueError("Cannot init read-only storage")
+
+        data = json.load(open(self.images_json))
+        changed = False
+        for idx, row in enumerate(data):
+            if row["id"] != img_id:
+                continue
+
+            updated = dict(row)
+            if tag in updated.get("names", []):
+                updated["names"] = [
+                    name for name in updated["names"] if name != tag
+                ]
+                changed = True
+            if tag in updated.get("names-history", []):
+                updated["names-history"] = [
+                    name for name in updated["names-history"]
+                    if name != tag
+                ]
+                changed = True
+
+            if not updated.get("names-history", []):
+                del data[idx]
+                updated = None
+                changed = True
+            else:
+                data[idx] = updated
+
+            if changed:
+                json.dump(data, open(self.images_json, "w"))
+                logging.debug(f"Updated {self.images_json}")
+                self.refresh()
+            return updated
+
+        return None
+
     def get_squash_filename(self, link):
         return os.path.join(self.overlay_dir, "l", f"{link}.squash")
 
@@ -474,6 +519,30 @@ class MigrateUtils:
         logging.info("Created squash image")
         return True
 
+    def _delete_migrated_image_data(self, img_id, top_id):
+        # The squashed payload is stored in the top layer for migrated images.
+        ln = self.dst.read_link_file(top_id)
+        sqf = self.dst.get_squash_filename(ln)
+        if os.path.exists(sqf):
+            logging.info("Removing squash file")
+            os.unlink(sqf)
+
+        link_path = os.path.join(self.dst.overlay_dir, "l", ln)
+        if os.path.lexists(link_path):
+            os.unlink(link_path)
+
+        overlay_path = os.path.join(self.dst.overlay_dir, top_id)
+        if os.path.exists(overlay_path):
+            rmtree(overlay_path)
+
+        layer_blob = os.path.join(self.dst.layers_dir, f"{top_id}.tar-split.gz")
+        if os.path.exists(layer_blob):
+            os.unlink(layer_blob)
+
+        self.dst.del_rec("layers", top_id)
+        logging.info("Removing image record")
+        self.dst.del_rec("images", img_id)
+
     def migrate_image(self, image):
         self._lazy_init()
         logging.debug(f"Migrating {image}")
@@ -531,23 +600,17 @@ class MigrateUtils:
         self._lazy_init()
         logging.debug(f"Removing {image}")
         self.dst.refresh()
-        img_info, _ = self.dst.get_img_info(image)
+        img_info, fullname = self.dst.get_img_info(image)
         if not img_info:
             logging.error(f"Image {image} not found\n")
             return False
         img_id = img_info["id"]
         top_id = img_info["layer"]
-        # Get the layers from the manifest
-        rld = self._get_img_layers(self.dst, top_id)
+        tag = fullname or image
 
-        # make sure the src squash file exist
-        ln = self.dst.read_link_file(top_id)
-        sqf = self.dst.get_squash_filename(ln)
-        if os.path.exists(sqf):
-            logging.info("Removing squash file")
-            os.unlink(sqf)
-        logging.info("Removing image record")
-        self.dst.del_rec("images", img_id)
+        updated = self.dst.remove_image_tag(img_id, tag)
+        if updated is None:
+            self._delete_migrated_image_data(img_id, top_id)
         return True
 
 

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -617,6 +617,10 @@ class MigrateUtils:
             return False
         img_id = img_info["id"]
         top_id = img_info["layer"]
+        if fullname == img_id:
+            self._delete_migrated_image_data(img_id, top_id)
+            return True
+
         tag = fullname or image
 
         updated = self.dst.remove_image_tag(img_id, tag)

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -204,6 +204,51 @@ class ImageStore:
             logging.debug(f"Updated {fn}")
             self.refresh()
 
+    @staticmethod
+    def _merge_unique(existing, new):
+        merged = []
+        for item in existing + new:
+            if item not in merged:
+                merged.append(item)
+        return merged
+
+    def upsert_image(self, img_info):
+        """
+        Add or update an image record in images.json.
+
+        For an existing image ID, merge tag metadata so alternate names for the
+        same content remain visible in the destination store.
+        """
+        if self.read_only:
+            raise ValueError("Cannot init read-only stroage")
+
+        data = json.load(open(self.images_json))
+        changed = False
+        for idx, row in enumerate(data):
+            if row["id"] != img_info["id"]:
+                continue
+            updated = dict(row)
+            updated.update(img_info)
+            updated["names"] = self._merge_unique(
+                row.get("names", []), img_info.get("names", [])
+            )
+            updated["names-history"] = self._merge_unique(
+                row.get("names-history", []),
+                img_info.get("names-history", []) + img_info.get("names", []),
+            )
+            if updated != row:
+                data[idx] = updated
+                changed = True
+            break
+        else:
+            data.append(img_info)
+            changed = True
+
+        if changed:
+            json.dump(data, open(self.images_json, "w"))
+            logging.debug(f"Updated {self.images_json}")
+            self.refresh()
+
     def get_squash_filename(self, link):
         return os.path.join(self.overlay_dir, "l", f"{link}.squash")
 
@@ -429,15 +474,17 @@ class MigrateUtils:
         # make sure the src squash file exist
         logging.debug(f"Reading link: {top_id}")
 
-        if self.dst.chk_image(img_id):
-            logging.info("Previously migrated")
-            return True
-
         # Check if previously tagged image exist
         dimg = None
         if fullname:
             dimg, _ = self.dst.get_img_info(fullname)
-        self.dst.drop_tag(img_info["names"])
+        if dimg and dimg["id"] != img_id:
+            self.dst.drop_tag(img_info["names"])
+
+        if self.dst.chk_image(img_id):
+            logging.info("Previously migrated")
+            self.dst.upsert_image(img_info)
+            return True
 
         # Copy image info
         self._copy_image_info(img_id)
@@ -456,7 +503,7 @@ class MigrateUtils:
 
         # Add img to images.json
         # Save this for the end so things are all ready
-        self.dst.add_recs("images", [img_info])
+        self.dst.upsert_image(img_info)
         return True
 
     def remove_image(self, image):

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -245,26 +245,31 @@ class ImageStore:
             raise ValueError("Cannot init read-only storage")
 
         data = json.load(open(self.images_json))
-        changed = False
+        existing_idx = None
+        existing_row = None
         for idx, row in enumerate(data):
-            if row["id"] != img_info["id"]:
-                continue
-            updated = dict(row)
-            updated.update(img_info)
-            updated["names"] = self._merge_unique(
-                row.get("names", []), img_info.get("names", [])
-            )
-            updated["names-history"] = self._merge_unique(
-                row.get("names-history", []),
-                img_info.get("names-history", []) + img_info.get("names", []),
-            )
-            if updated != row:
-                data[idx] = updated
-                changed = True
-            break
-        else:
+            if row["id"] == img_info["id"]:
+                existing_idx = idx
+                existing_row = row
+                break
+
+        changed = False
+        if existing_row is None:
             data.append(img_info)
             changed = True
+        else:
+            updated = dict(existing_row)
+            updated.update(img_info)
+            updated["names"] = self._merge_unique(
+                existing_row.get("names", []), img_info.get("names", [])
+            )
+            updated["names-history"] = self._merge_unique(
+                existing_row.get("names-history", []),
+                img_info.get("names-history", []) + img_info.get("names", []),
+            )
+            if updated != existing_row:
+                data[existing_idx] = updated
+                changed = True
 
         if changed:
             json.dump(data, open(self.images_json, "w"))
@@ -282,38 +287,44 @@ class ImageStore:
             raise ValueError("Cannot init read-only storage")
 
         data = json.load(open(self.images_json))
-        changed = False
+        existing_idx = None
+        existing_row = None
         for idx, row in enumerate(data):
-            if row["id"] != img_id:
-                continue
+            if row["id"] == img_id:
+                existing_idx = idx
+                existing_row = row
+                break
 
-            updated = dict(row)
-            if tag in updated.get("names", []):
-                updated["names"] = [
-                    name for name in updated["names"] if name != tag
-                ]
-                changed = True
-            if tag in updated.get("names-history", []):
-                updated["names-history"] = [
-                    name for name in updated["names-history"]
-                    if name != tag
-                ]
-                changed = True
+        if existing_row is None:
+            return None
 
-            if not updated.get("names-history", []):
-                del data[idx]
-                updated = None
-                changed = True
-            else:
-                data[idx] = updated
+        updated = dict(existing_row)
+        changed = False
+        if tag in updated.get("names", []):
+            updated["names"] = [
+                name for name in updated["names"] if name != tag
+            ]
+            changed = True
+        if tag in updated.get("names-history", []):
+            updated["names-history"] = [
+                name for name in updated["names-history"]
+                if name != tag
+            ]
+            changed = True
 
-            if changed:
-                json.dump(data, open(self.images_json, "w"))
-                logging.debug(f"Updated {self.images_json}")
-                self.refresh()
-            return updated
+        if not updated.get("names-history", []):
+            del data[existing_idx]
+            updated = None
+            changed = True
+        else:
+            data[existing_idx] = updated
 
-        return None
+        if changed:
+            json.dump(data, open(self.images_json, "w"))
+            logging.debug(f"Updated {self.images_json}")
+            self.refresh()
+
+        return updated
 
     def get_squash_filename(self, link):
         return os.path.join(self.overlay_dir, "l", f"{link}.squash")

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -73,9 +73,30 @@ class ImageStore:
                 return img, img["id"]
         if ":" not in img_name:
             img_name = f"{img_name}:latest"
-        prefs = ["", "docker.io/", "docker.io/library/", "localhost/"]
-        for pref in prefs:
-            long_name = f"{pref}{img_name}"
+
+        long_names = [img_name]
+        first_part = img_name.split("/", 1)[0]
+        has_registry = "/" in img_name and (
+            "." in first_part or ":" in first_part
+            or first_part == "localhost"
+        )
+
+        if not has_registry:
+            long_names.extend([
+                f"docker.io/{img_name}",
+                f"docker.io/library/{img_name}",
+                f"localhost/{img_name}",
+            ])
+        elif img_name.startswith("docker.io/"):
+            remainder = img_name[len("docker.io/"):]
+            if "/" not in remainder:
+                long_names.append(f"docker.io/library/{remainder}")
+        elif img_name.startswith("docker.io/library/"):
+            remainder = img_name[len("docker.io/library/"):]
+            if "/" not in remainder:
+                long_names.append(f"docker.io/{remainder}")
+
+        for long_name in long_names:
             for img in self.images:
                 for n in img.get("names", []):
                     if long_name == n:

--- a/podman_hpc/migrate2scratch.py
+++ b/podman_hpc/migrate2scratch.py
@@ -119,7 +119,7 @@ class ImageStore:
         the minimum directories and JSON files.
         """
         if self.read_only:
-            raise ValueError("Cannot init read-only stroage")
+            raise ValueError("Cannot init read-only storage")
 
         if not os.path.exists(self.base):
             os.mkdir(self.base)
@@ -159,7 +159,7 @@ class ImageStore:
         key: key name for the ID
         """
         if self.read_only:
-            raise ValueError("Cannot init read-only stroage")
+            raise ValueError("Cannot init read-only storage")
 
         fn = os.path.join(self.base, f"overlay-{otype}", f"{otype}.json")
         data = json.load(open(fn))
@@ -184,7 +184,7 @@ class ImageStore:
         tags: list of tags
         """
         if self.read_only:
-            raise ValueError("Cannot init read-only stroage")
+            raise ValueError("Cannot init read-only storage")
 
         data = self.images
  
@@ -207,7 +207,7 @@ class ImageStore:
               for duplicate IDs.
         """
         if self.read_only:
-            raise ValueError("Cannot init read-only stroage")
+            raise ValueError("Cannot init read-only storage")
 
         fn = os.path.join(self.base, f"overlay-{otype}", f"{otype}.json")
         data = json.load(open(fn))
@@ -241,7 +241,7 @@ class ImageStore:
         same content remain visible in the destination store.
         """
         if self.read_only:
-            raise ValueError("Cannot init read-only stroage")
+            raise ValueError("Cannot init read-only storage")
 
         data = json.load(open(self.images_json))
         changed = False

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -101,10 +101,18 @@ def test_migrate_remove(src, tmp_path, mocker):
     assert resp
     assert get_count(mu.dst.images_json, img) == 1
 
+    migrated = json.load(open(mu.dst.images_json))[0]
+    layer = migrated["layer"]
+    link = mu.dst.read_link_file(layer)
+    sqf = mu.dst.get_squash_filename(link)
+    open(sqf, "w").close()
+
     # Test removing the image
     resp = mu.remove_image(img)
     assert resp
     assert get_count(mu.dst.images_json, img) == 0
+    assert not os.path.exists(sqf)
+    assert not os.path.exists(os.path.join(tmp_path, "overlay", layer))
 
 
 def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
@@ -131,3 +139,41 @@ def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
     assert mu.migrate_image(img_edge)
     assert get_count(mu.dst.images_json, img_latest) == 1
     assert get_count(mu.dst.images_json, img_edge) == 1
+
+
+def test_remove_image_only_drops_requested_tag_until_history_empty(
+    src, tmp_path, mocker
+):
+    img_latest = "docker.io/library/alpine:latest"
+    img_edge = "docker.io/library/alpine:edge"
+    src_copy = tmp_path / "src"
+    dst = tmp_path / "dst"
+    copytree(src, src_copy)
+
+    src_images = src_copy / "overlay-images" / "images.json"
+    data = json.load(open(src_images))
+    data[0]["names"].append(img_edge)
+    data[0]["names-history"].append(img_edge)
+    json.dump(data, open(src_images, "w"))
+
+    popen = mocker.patch("podman_hpc.migrate2scratch.Popen")
+    popen.return_value = mockproc()
+
+    mu = MigrateUtils(src=str(src_copy), dst=str(dst))
+    assert mu.migrate_image(img_latest)
+
+    migrated = json.load(open(mu.dst.images_json))[0]
+    layer = migrated["layer"]
+    link = mu.dst.read_link_file(layer)
+    sqf = mu.dst.get_squash_filename(link)
+    open(sqf, "w").close()
+
+    assert mu.remove_image(img_edge)
+    remaining = json.load(open(mu.dst.images_json))[0]
+    assert remaining["names"] == [img_latest]
+    assert remaining["names-history"] == [img_latest]
+    assert os.path.exists(sqf)
+
+    assert mu.remove_image(img_latest)
+    assert json.load(open(mu.dst.images_json)) == []
+    assert not os.path.exists(sqf)

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -114,6 +114,19 @@ def test_migrate_remove(src, tmp_path, mocker):
     assert not os.path.exists(sqf)
     assert not os.path.exists(os.path.join(tmp_path, "overlay", layer))
 
+    assert mu.migrate_image(img)
+    migrated = json.load(open(mu.dst.images_json))[0]
+    layer = migrated["layer"]
+    link = mu.dst.read_link_file(layer)
+    sqf = mu.dst.get_squash_filename(link)
+    open(sqf, "w").close()
+
+    resp = mu.remove_image(hash)
+    assert resp
+    assert get_count(mu.dst.images_json, img) == 0
+    assert not os.path.exists(sqf)
+    assert not os.path.exists(os.path.join(tmp_path, "overlay", layer))
+
 
 def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
     img_latest = "docker.io/library/ubuntu:jammy"

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -124,8 +124,8 @@ def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
 
     src_images = src_copy / "overlay-images" / "images.json"
     data = json.load(open(src_images))
-    data[0]["names"].append(img_edge)
-    data[0]["names-history"].append(img_edge)
+    data[0]["names"] = [img_latest, img_edge]
+    data[0]["names-history"] = [img_latest, img_edge]
     json.dump(data, open(src_images, "w"))
 
     popen = mocker.patch("podman_hpc.migrate2scratch.Popen")
@@ -152,8 +152,8 @@ def test_remove_image_only_drops_requested_tag_until_history_empty(
 
     src_images = src_copy / "overlay-images" / "images.json"
     data = json.load(open(src_images))
-    data[0]["names"].append(img_edge)
-    data[0]["names-history"].append(img_edge)
+    data[0]["names"] = [img_latest, img_edge]
+    data[0]["names-history"] = [img_latest, img_edge]
     json.dump(data, open(src_images, "w"))
 
     popen = mocker.patch("podman_hpc.migrate2scratch.Popen")

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -116,8 +116,8 @@ def test_migrate_remove(src, tmp_path, mocker):
 
 
 def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
-    img_latest = "docker.io/library/alpine:latest"
-    img_edge = "docker.io/library/alpine:edge"
+    img_latest = "docker.io/library/ubuntu:jammy"
+    img_edge = "docker.io/library/ubuntu:22.04"
     src_copy = tmp_path / "src"
     dst = tmp_path / "dst"
     copytree(src, src_copy)
@@ -144,8 +144,8 @@ def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
 def test_remove_image_only_drops_requested_tag_until_history_empty(
     src, tmp_path, mocker
 ):
-    img_latest = "docker.io/library/alpine:latest"
-    img_edge = "docker.io/library/alpine:edge"
+    img_latest = "docker.io/library/ubuntu:jammy"
+    img_edge = "docker.io/library/ubuntu:22.04"
     src_copy = tmp_path / "src"
     dst = tmp_path / "dst"
     copytree(src, src_copy)

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -54,6 +54,15 @@ def test_bad_image_name(src):
         mu.migrate_image("balpine")
 
 
+def test_get_img_info_fully_qualified_dockerhub_name(src):
+    mu = MigrateUtils(src=src, dst="/tmp/unused")
+    mu._lazy_init()
+
+    img, fullname = mu.src.get_img_info("docker.io/alpine:latest")
+    assert img is not None
+    assert fullname == "docker.io/library/alpine:latest"
+
+
 def test_migrate_remove(src, tmp_path, mocker):
     img = "docker.io/library/alpine:latest"
     hash = "9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5"

--- a/test/test_migrate2scratch.py
+++ b/test/test_migrate2scratch.py
@@ -2,6 +2,7 @@ from podman_hpc.migrate2scratch import MigrateUtils
 import os
 import json
 import pytest
+from shutil import copytree
 from tempfile import TemporaryDirectory
 
 
@@ -95,3 +96,29 @@ def test_migrate_remove(src, tmp_path, mocker):
     resp = mu.remove_image(img)
     assert resp
     assert get_count(mu.dst.images_json, img) == 0
+
+
+def test_migrate_existing_image_adds_new_tag(src, tmp_path, mocker):
+    img_latest = "docker.io/library/alpine:latest"
+    img_edge = "docker.io/library/alpine:edge"
+    src_copy = tmp_path / "src"
+    dst = tmp_path / "dst"
+    copytree(src, src_copy)
+
+    src_images = src_copy / "overlay-images" / "images.json"
+    data = json.load(open(src_images))
+    data[0]["names"].append(img_edge)
+    data[0]["names-history"].append(img_edge)
+    json.dump(data, open(src_images, "w"))
+
+    popen = mocker.patch("podman_hpc.migrate2scratch.Popen")
+    popen.return_value = mockproc()
+
+    mu = MigrateUtils(src=str(src_copy), dst=str(dst))
+    assert mu.migrate_image(img_latest)
+    assert get_count(mu.dst.images_json, img_latest) == 1
+    assert get_count(mu.dst.images_json, img_edge) == 1
+
+    assert mu.migrate_image(img_edge)
+    assert get_count(mu.dst.images_json, img_latest) == 1
+    assert get_count(mu.dst.images_json, img_edge) == 1


### PR DESCRIPTION
Fix migrated-image retagging when the image content already exists in the squash store.

Before this change, `migrate_image()` returned early as soon as the destination store already contained the image ID. That skipped the metadata update in `overlay-images/images.json`, so pulling the same image content under a second
tag could report migration success while leaving the new tag unavailable for later `podman-hpc run` lookups.

This patch changes migration to treat "already migrated" as "image data is already present, but tag metadata may still need reconciliation". It adds an image upsert path that:

- merges `names` onto an existing image record instead of ignoring duplicate IDs
- merges `names-history` so alternate tags remain visible in the destination store
- only drops an existing tag when that tag currently points to a different image ID

As a result, repeated pulls of the same image hash under different tags now keep the squash store metadata consistent, and `podman-hpc` can find the migrated image through either tag.

Testing:

- added a regression test covering migration of the same image ID under a second tag
- locally verified the exact scenario with a direct Python harness because this
  environment is missing `pytest-mock` and the repository `setup.cfg` currently
  causes pytest config parsing issues here
