### PR TITLE
bump PyPa publish GitHub action to latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           uses: ./.github/actions/build-podman-hpc
 
         - name: Publish package to PyPI
-          uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 #v1.12.3
+          uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b #v1.14.0
 
         - name: Release
           id: release


### PR DESCRIPTION
Updating the pypa publish action so the release pipeline runs again.