### PR TITLE
overwrite container entrypoint in shared-run

### DIFF
--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -291,6 +291,11 @@ def _shared_run(conf, run_args, **site_opts):
         cpt.filterValidOptions(options, [conf.podman_bin, "run", "--help"])
     )
     run_cmd.extend(conf.get_cmd_extensions("run", site_opts))
+    # shared-run starts a persistent per-node container and then launches
+    # application ranks with podman exec. Ignore the image entrypoint for the
+    # keepalive container so ENTRYPOINT ["/bin/bash"] does not wrap
+    # "sleep infinity" as "/bin/bash sleep infinity".
+    run_cmd.append("--entrypoint=")
     run_cmd.append(image)
     run_cmd.extend(conf.shared_run_command)
 

--- a/podman_hpc/podman_hpc.py
+++ b/podman_hpc/podman_hpc.py
@@ -295,7 +295,8 @@ def _shared_run(conf, run_args, **site_opts):
     # application ranks with podman exec. Ignore the image entrypoint for the
     # keepalive container so ENTRYPOINT ["/bin/bash"] does not wrap
     # "sleep infinity" as "/bin/bash sleep infinity".
-    run_cmd.append("--entrypoint=")
+    if not any(opt == "--entrypoint" or opt.startswith("--entrypoint=") for opt in options):
+        run_cmd.append("--entrypoint=")
     run_cmd.append(image)
     run_cmd.extend(conf.shared_run_command)
 

--- a/test/test_podman_hpc.py
+++ b/test/test_podman_hpc.py
@@ -93,6 +93,7 @@ def test_shared_run(monkeypatch, fix_paths, mock_podman, mock_exit):
     assert "--root" in run
     assert f"/tmp/{uid}_hpc/storage" in run
     assert "--name" in run
+    assert "--entrypoint=" in run
     assert "ubuntu" in run
     assert exec is not None
     assert exec[-1] == "uptime"


### PR DESCRIPTION
 * `podman_hpc/podman_hpc.py` now adds `--entrypoint=` to the detached podman run used by shared-run,
    so the shared keepalive command ignores image ENTRYPOINT.
* `test/test_podman_hpc.py` now asserts the generated shared-run podman run includes `--entrypoint=`.
