### PR TITLE
Dfulton/python3.6 build pep625 compliant

### DIFF
--- a/podman-hpc.spec
+++ b/podman-hpc.spec
@@ -12,6 +12,13 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
+%define pypa() %{lua:
+x = rpm.expand('%1')
+for _,s in ipairs({'-','%.'}) do
+  x,_ = string.gsub(x,s,'_')
+end
+print(x)
+}
 
 Name:           podman-hpc
 Version:        1.2.2
@@ -20,7 +27,7 @@ Summary:	Scripts to enable Podman to run in an HPC environment
 # FIXME: Select a correct license from https://github.com/openSUSE/spec-cleaner#spdx-licenses
 License:        Apache 2.0 
 URL:            https://github.com/nersc/podman-hpc 
-Source:         %{name}-%{version}.tar.gz
+Source:         %{pypa %{python_dist_name %name}}-%{version}.tar.gz
 BuildRequires:  python3
 Requires:       podman
 Requires:       python3-toml
@@ -34,7 +41,7 @@ effectively and scale in an HPC environment.  It is designed to
 run fully unprivileged.
 
 %prep
-%setup -q
+%setup -q -n %{pypa %{python_dist_name %name}}-%{version}
 
 %build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
   "setuptools>=40",
+  "packaging",
+  "importlib-metadata; python_version <= '3.7'",
+  "importlib; python_version >= '3.8'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,34 @@
 import subprocess
 from setuptools import setup
 from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
+from packaging.version import Version
+try:
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    from importlib_metadata import version
 
+_monkeypatch_pep625 = (Version(version("setuptools")) < Version("69.3.0"))
 
-class BuildMakeCommand (build_py):
+if _monkeypatch_pep625:
+    from types import MethodType
+    from packaging.utils import canonicalize_name, canonicalize_version
+    def _get_fullname_canonicalized(self):
+        return "{}-{}".format(
+            canonicalize_name(self.get_name()).replace('-','_'),
+            canonicalize_version(self.get_version()),
+        )
+
+class build_py_with_make_epilogue(build_py):
     def run(self):
         super(build_py, self).run()
         subprocess.run(['make', 'setuptools-build_py'], check=True)
 
+class sdist_pep625(sdist):
+    def make_distribution(self):
+        if _monkeypatch_pep625:
+            self.distribution.get_fullname = MethodType(_get_fullname_canonicalized, self.distribution)
+        super(sdist, self).make_distribution()
 
 if __name__ == "__main__":
-    setup(cmdclass={'build_py': BuildMakeCommand})
+    setup(cmdclass={'build_py': build_py_with_make_epilogue, 'sdist': sdist_pep625})

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ if _monkeypatch_pep625:
 
 class build_py_with_make_epilogue(build_py):
     def run(self):
-        super(build_py, self).run()
+        super(build_py_with_make_epilogue, self).run()
         subprocess.run(['make', 'setuptools-build_py'], check=True)
 
 class sdist_pep625(sdist):
     def make_distribution(self):
         if _monkeypatch_pep625:
             self.distribution.get_fullname = MethodType(_get_fullname_canonicalized, self.distribution)
-        super(sdist, self).make_distribution()
+        super(sdist_pep625, self).make_distribution()
 
 if __name__ == "__main__":
     setup(cmdclass={'build_py': build_py_with_make_epilogue, 'sdist': sdist_pep625})


### PR DESCRIPTION
This includes a monkeypatch to build.sh which allows the python sdist build to produce a pypa compliant (see PEP625) sdist tarball which can be uploaded to PyPI, and then a few changes to the RPM specfile to consume the new name (the sdist tarball is a source for the RPM build).